### PR TITLE
[WIP] Various fixes to COLR/CPAL support

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -31,6 +31,7 @@ export default class TTFFont {
     this._directoryPos = this.stream.pos;
     this._tables = {};
     this._glyphs = {};
+    this._baseGlyphs = {};
     this._decodeDirectory();
 
     // define properties for each table to lazily parse
@@ -375,16 +376,16 @@ export default class TTFFont {
   }
 
   _getBaseGlyph(glyph, characters = []) {
-    if (!this._glyphs[glyph]) {
+    if (!this._baseGlyphs[glyph]) {
       if (this.directory.tables.glyf) {
-        this._glyphs[glyph] = new TTFGlyph(glyph, characters, this);
+        this._baseGlyphs[glyph] = new TTFGlyph(glyph, characters, this);
 
       } else if (this.directory.tables['CFF '] || this.directory.tables.CFF2) {
-        this._glyphs[glyph] = new CFFGlyph(glyph, characters, this);
+        this._baseGlyphs[glyph] = new CFFGlyph(glyph, characters, this);
       }
     }
 
-    return this._glyphs[glyph] || null;
+    return this._baseGlyphs[glyph] || null;
   }
 
   /**
@@ -405,7 +406,7 @@ export default class TTFFont {
         this._glyphs[glyph] = new COLRGlyph(glyph, characters, this);
 
       } else {
-        this._getBaseGlyph(glyph, characters);
+        this._glyphs[glyph] = this._getBaseGlyph(glyph, characters);
       }
     }
 

--- a/src/glyph/COLRGlyph.js
+++ b/src/glyph/COLRGlyph.js
@@ -55,21 +55,14 @@ export default class COLRGlyph extends Glyph {
     // default to normal glyph from glyf or CFF
     if (baseLayer == null) {
       var g = this._font._getBaseGlyph(this.id);
-      var color = {
-        red: 0,
-        green: 0,
-        blue: 0,
-        alpha: 255
-      };
-
-      return [new COLRLayer(g, color)];
+      return [new COLRLayer(g, null)];
     }
 
     // otherwise, return an array of all the layers
     let layers = [];
     for (let i = baseLayer.firstLayerIndex; i < baseLayer.firstLayerIndex + baseLayer.numLayers; i++) {
       var rec = colr.layerRecords[i];
-      var color = cpal.colorRecords[rec.paletteIndex];
+      var color = cpal.colorRecords[rec.paletteIndex] || null;
       var g = this._font._getBaseGlyph(rec.gid);
       layers.push(new COLRLayer(g, color));
     }
@@ -79,8 +72,19 @@ export default class COLRGlyph extends Glyph {
 
   render(ctx, size) {
     for (let {glyph, color} of this.layers) {
-      ctx.fillColor([color.red, color.green, color.blue], color.alpha / 255 * 100);
+      ctx.save();
+
+      if (color) {
+        ctx.fillStyle = 'rgba(' + [
+          color.red,
+          color.green,
+          color.blue,
+          color.alpha / 255 * 100
+        ].join(',') + ')';
+      }
       glyph.render(ctx, size);
+
+      ctx.restore();
     }
 
     return;

--- a/src/glyph/TTFGlyph.js
+++ b/src/glyph/TTFGlyph.js
@@ -271,7 +271,7 @@ export default class TTFGlyph extends Glyph {
     if (glyph.numberOfContours < 0) {
       // resolve composite glyphs
       for (let component of glyph.components) {
-        let contours = this._font.getGlyph(component.glyphID)._getContours();
+        let contours = this._font._getBaseGlyph(component.glyphID)._getContours();
         for (let i = 0; i < contours.length; i++) {
           let contour = contours[i];
           for (let j = 0; j < contour.length; j++) {


### PR DESCRIPTION
This is an incomplete attempt to get [Amiri Quran Colored](https://github.com/alif-type/amiri/blob/master/amiri-quran-colored.ttf) rendered correctly.

* There is no `CanvasRenderingContext2D.fillColor()` function (at least not in Chrome and Firefox). It seems that `fillStyle` property is what was meant here.
* It seems that `save()` and `restore()` calls are needed, other wise the `fillStyle` change would leak to next glyphs. This don’t seem to work completely; this is what I get right now:
  ![fontkit](https://user-images.githubusercontent.com/93914/27156762-3d1bdbac-5167-11e7-8c71-0d4359e9d3ae.png)
  but it should be:
  ![firefox](https://user-images.githubusercontent.com/93914/27157005-4602b988-5168-11e7-952e-37be36c04ee5.png)
  I’m really stuck here, no idea what is going on.
* Not all layers have colors, so the presence of color should be checked before attempting to use it.
* When color in undefined (e.g. the color index is 0xFFF), it is set to null and the check above make sure no color is set.
* Calling `glyph.render()` results in infinite recursion, this is because `_getBaseGlyph()` will return a `COLRGlyph` not `TTFGlyph`. Now color and non-color glyphs are saved in different arrays, not sure if this is the cleanest way.