### PR TITLE
Remove duplicate copies of decorator helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "rollup": "^0.34.10",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-json": "^2.0.2",
-    "rollup-plugin-local-resolve": "^1.0.7"
+    "rollup-plugin-local-resolve": "^1.0.7",
+    "rollup-plugin-re": "^1.0.7"
   },
   "browserify": {
     "transform": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import babel from 'rollup-plugin-babel';
 import localResolve from 'rollup-plugin-local-resolve';
 import json from 'rollup-plugin-json';
+import replace from 'rollup-plugin-re';
 
 export default {
   format: 'cjs',
@@ -12,6 +13,41 @@ export default {
       presets: [['es2015', { modules: false, loose: true }]],
       plugins: ['transform-decorators-legacy', 'transform-class-properties', 'transform-runtime'],
       runtimeHelpers: true
+    }),
+    replace({
+      patterns:[{
+        test: /function _applyDecoratedDescriptor[^]*return desc;[^]*?}/,
+        replace: ''
+      }]
     })
-  ]
+  ],
+  intro: `function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) {
+  var desc = {};
+  Object.keys(descriptor).forEach(function (key) {
+    desc[key] = descriptor[key];
+  });
+  desc.enumerable = !!desc.enumerable;
+  desc.configurable = !!desc.configurable;
+
+  if ('value' in desc || desc.initializer) {
+    desc.writable = true;
+  }
+
+  desc = decorators.slice().reverse().reduce(function (desc, decorator) {
+    return decorator(target, property, desc) || desc;
+  }, desc);
+
+  if (context && desc.initializer !== void 0) {
+    desc.value = desc.initializer ? desc.initializer.call(context) : void 0;
+    desc.initializer = undefined;
+  }
+
+  if (desc.initializer === void 0) {
+    Object.defineProperty(target, property, desc);
+    desc = null;
+  }
+
+  return desc;
+}
+`
 };


### PR DESCRIPTION
Currently the build includes 5 copies of `_applyDecoratedDescriptor`

This PR modify rollup config to ensure only one copy is bundled