### PR TITLE
Update the CI node versions to reflect current LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 node_js:
   - stable
+  - "8"
   - "6"
-  - "4"
-matrix:
-  include:
-    - os: osx
-      node_js: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - stable
   - "8"
   - "6"
+matrix:
+  include:
+    - os: osx
+      node_js: stable


### PR DESCRIPTION
Also removed the osx-specific retesting for Node "stable", which doesn't really add anything on top of the Node stable that already runs.