### PR TITLE
fix the entrySelector calculation

### DIFF
--- a/src/tables/directory.js
+++ b/src/tables/directory.js
@@ -44,7 +44,8 @@ Directory.preEncode = function(stream) {
   this.numTables = tables.length;
   this.tables = tables;
 
-  let maxPowerOf2 = 2 ** Math.floor((Math.log(this.numTables) / Math.LN2));
+  let maxExponentFor2 = Math.floor((Math.log(this.numTables) / Math.LN2));
+  let maxPowerOf2 = Math.pow(2, maxExponentFor2);
   this.searchRange =  maxPowerOf2 * 16;
   this.entrySelector = Math.log(maxPowerOf2) / Math.LN2;
   this.rangeShift = this.numTables * 16 - this.searchRange;

--- a/src/tables/directory.js
+++ b/src/tables/directory.js
@@ -44,8 +44,9 @@ Directory.preEncode = function(stream) {
   this.numTables = tables.length;
   this.tables = tables;
 
-  this.searchRange = Math.floor(Math.log(this.numTables) / Math.LN2) * 16;
-  this.entrySelector = Math.floor(this.searchRange / Math.LN2);
+  let maxPowerOf2 = 2 ** Math.floor((Math.log(this.numTables) / Math.LN2));
+  this.searchRange =  maxPowerOf2 * 16;
+  this.entrySelector = Math.log(maxPowerOf2) / Math.LN2;
   this.rangeShift = this.numTables * 16 - this.searchRange;
 };
 

--- a/src/tables/directory.js
+++ b/src/tables/directory.js
@@ -46,6 +46,7 @@ Directory.preEncode = function(stream) {
 
   let maxExponentFor2 = Math.floor((Math.log(this.numTables) / Math.LN2));
   let maxPowerOf2 = Math.pow(2, maxExponentFor2);
+
   this.searchRange =  maxPowerOf2 * 16;
   this.entrySelector = Math.log(maxPowerOf2) / Math.LN2;
   this.rangeShift = this.numTables * 16 - this.searchRange;

--- a/test/directory.js
+++ b/test/directory.js
@@ -1,12 +1,11 @@
 import fontkit from '../src';
 import assert from 'assert';
-import BBox from '../src/glyph/BBox';
 
 describe('metadata', function() {
-  let ttfFont = fontkit.openSync(__dirname + '/data/OpenSans/OpenSans-Regular.ttf');
+  let font = fontkit.openSync(__dirname + '/data/OpenSans/OpenSans-Regular.ttf');
 
   it('decodes SFNT directory values correctly', function() {
-    let dir = ttfFont.directory;
+    let dir = font.directory;
     assert.equal(dir.numTables, 19);
     assert.equal(dir.searchRange, 256);
     assert.equal(dir.entrySelector, 4);
@@ -14,7 +13,7 @@ describe('metadata', function() {
   });
 
   it('numTables matches table collection', function() {
-    let dir = ttfFont.directory;
+    let dir = font.directory;
     assert.equal(Object.keys(dir.tables).length, dir.numTables);
   });
 

--- a/test/directory.js
+++ b/test/directory.js
@@ -1,0 +1,21 @@
+import fontkit from '../src';
+import assert from 'assert';
+import BBox from '../src/glyph/BBox';
+
+describe('metadata', function() {
+  let ttfFont = fontkit.openSync(__dirname + '/data/OpenSans/OpenSans-Regular.ttf');
+
+  it('decodes SFNT directory values correctly', function() {
+    let dir = ttfFont.directory;
+    assert.equal(dir.numTables, 19);
+    assert.equal(dir.searchRange, 256);
+    assert.equal(dir.entrySelector, 4);
+    assert.equal(dir.rangeShift, 48);
+  });
+
+  it('numTables matches table collection', function() {
+    let dir = ttfFont.directory;
+    assert.equal(Object.keys(dir.tables).length, dir.numTables);
+  });
+
+});


### PR DESCRIPTION
The spec for the searchRange and entrySelector specifies the following constraints:

>searchRange:	(Maximum power of 2 <= numTables) x 16
>entrySelector:	Log2(maximum power of 2 <= numTables)
>rangeShift:	NumTables x 16-searchRange

But the code was computing `searchRange` as just the power index, not the actual power of two that it should be.

Fixes #149 
Fixes #179