### PR TITLE
Enable `fontkit` to work in the browser via Browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ coverage.html
 data.trie
 /index.js
 /base.js
+/browser.js
+/browser.min.js
 *.js.map
 use.trie
 use.json

--- a/package.json
+++ b/package.json
@@ -13,14 +13,16 @@
   ],
   "scripts": {
     "test": "mocha",
-    "prepublish": "run-s clean trie:** rollup:**",
+    "prepublish": "run-s clean trie:** rollup:** browserify:**",
     "trie:data": "babel-node src/opentype/shapers/generate-data.js",
     "trie:use": "babel-node src/opentype/shapers/gen-use.js",
     "trie:indic": "babel-node src/opentype/shapers/gen-indic.js",
     "trie:copy": "shx cp src/opentype/shapers/*.trie ./",
     "rollup:index": "rollup -c -m -i src/index.js -o index.js",
     "rollup:base": "rollup -c -m -i src/base.js -o base.js",
-    "clean": "shx rm -f index.js base.js data.trie indic.trie use.trie src/opentype/shapers/data.trie src/opentype/shapers/use.trie src/opentype/shapers/use.json src/opentype/shapers/indic.trie src/opentype/shapers/indic.json",
+    "browserify:full": "browserify index.js --standalone FontKit --debug | exorcist browser.js.map > browser.js",
+    "browserify:min": "browserify index.js --standalone FontKit --debug --plugin=tinyify | exorcist browser.min.js.map > browser.min.js",
+    "clean": "shx rm -f index.js base.js browser.js browser.min.js *.map data.trie indic.trie use.trie src/opentype/shapers/data.trie src/opentype/shapers/use.trie src/opentype/shapers/use.json src/opentype/shapers/indic.trie src/opentype/shapers/indic.json",
     "coverage": "cross-env BABEL_ENV=cover nyc mocha"
   },
   "main": "index.js",
@@ -29,6 +31,10 @@
     "src",
     "base.js",
     "base.js.map",
+    "browser.js",
+    "browser.js.map",
+    "browser.min.js",
+    "browser.min.js.map",
     "index.js",
     "index.js.map",
     "data.trie",
@@ -58,11 +64,13 @@
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.14.0",
+    "browserify": "^16.2.3",
     "codepoints": "^1.2.0",
     "concat-stream": "^1.4.6",
     "cross-env": "^5.0.1",
     "esdoc": "^0.4.8",
     "esdoc-es7-plugin": "0.0.3",
+    "exorcist": "^1.0.1",
     "iconv-lite": "^0.4.13",
     "mocha": "^2.0.1",
     "npm-run-all": "^4.0.2",
@@ -71,7 +79,8 @@
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-json": "^2.0.2",
     "rollup-plugin-local-resolve": "^1.0.7",
-    "shx": "^0.2.2"
+    "shx": "^0.2.2",
+    "tinyify": "^2.5.0"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
     "trie:copy": "shx cp src/opentype/shapers/*.trie ./",
     "rollup:index": "rollup -c -m -i src/index.js -o index.js",
     "rollup:base": "rollup -c -m -i src/base.js -o base.js",
-    "browserify:full": "browserify index.js --standalone FontKit --debug | exorcist browser.js.map > browser.js",
-    "browserify:min": "browserify index.js --standalone FontKit --debug --plugin=tinyify | exorcist browser.min.js.map > browser.min.js",
+    "browserify:copy-temp": "shx cp index.js browser-temp.js && shx cp index.js.map browser-temp.js.map",
+    "browserify:full": "browserify browser-temp.js --standalone FontKit --debug | exorcist browser.js.map > browser.js",
+    "browserify:min": "browserify browser-temp.js --standalone FontKit --debug --plugin=tinyify | exorcist browser.min.js.map > browser.min.js",
+    "browserify:clean-temp": "shx rm -f browser-temp.js*",
     "clean": "shx rm -f index.js base.js browser.js browser.min.js *.map data.trie indic.trie use.trie src/opentype/shapers/data.trie src/opentype/shapers/use.trie src/opentype/shapers/use.json src/opentype/shapers/indic.trie src/opentype/shapers/indic.json",
     "coverage": "cross-env BABEL_ENV=cover nyc mocha"
   },
   "main": "index.js",
+  "browser": "browser.js",
   "jsnext:main": "src/index.js",
   "files": [
     "src",


### PR DESCRIPTION
An updated attempt at browserify'ing this module, so it can be used in the browser.

This should replace the previous attempt, https://github.com/foliojs/fontkit/pull/137, which is now stale and outdated.  