### PR TITLE
Adding repository entry to packages json so that it appears on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
   ],
   "author": "Devon Govett <devongovett@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/foliojs/fontkit.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "brfs": "^1.4.0",


### PR DESCRIPTION
Adds the repository entry with the github url to packages so that it appears on the npm page, making contributing easier.