### PR TITLE
Fix saving loca index format/version when subsetting

### DIFF
--- a/src/subset/TTFSubset.js
+++ b/src/subset/TTFSubset.js
@@ -57,7 +57,8 @@ export default class TTFSubset extends Subset {
     this.glyf = [];
     this.offset = 0;
     this.loca = {
-      offsets: []
+      offsets: [],
+      version: this.font.loca.version
     };
 
     this.hmtx = {
@@ -77,7 +78,6 @@ export default class TTFSubset extends Subset {
     maxp.numGlyphs = this.glyf.length;
 
     this.loca.offsets.push(this.offset);
-    Tables.loca.preEncode.call(this.loca);
 
     let head = cloneDeep(this.font.head);
     head.indexToLocFormat = this.loca.version;

--- a/src/tables/loca.js
+++ b/src/tables/loca.js
@@ -18,11 +18,6 @@ loca.process = function() {
 };
 
 loca.preEncode = function() {
-  if (this.version != null) return;
-
-  // assume this.offsets is a sorted array
-  this.version = this.offsets[this.offsets.length - 1] > 0xffff ? 1 : 0;
-
   if (this.version === 0) {
     for (let i = 0; i < this.offsets.length; i++) {
       this.offsets[i] >>>= 1;

--- a/test/subset.js
+++ b/test/subset.js
@@ -56,6 +56,23 @@ describe('font subsetting', function() {
         done();
       }));
     });
+
+    it('should handle fonts with long index to location format (indexToLocFormat = 1)', function(done) {
+      let font = fontkit.openSync(__dirname + '/data/FiraSans/FiraSans-Regular.ttf');
+      let subset = font.createSubset();
+      for (let glyph of font.glyphsForString('abcd')) {
+        subset.includeGlyph(glyph);
+      }
+
+      subset.encodeStream().pipe(concat(function(buf) {
+        let f = fontkit.create(buf);
+        assert.equal(f.numGlyphs, 5);
+        assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('a')[0].path.toSVG());
+        // must test also second glyph which has an odd loca index
+        assert.equal(f.getGlyph(2).path.toSVG(), font.glyphsForString('b')[0].path.toSVG());
+        done();
+      }));
+    });
   });
 
   describe('CFF subsetting', function() {


### PR DESCRIPTION
Fixes saving the loca index format when subsetting.

Fonts with version 1 (long format) were being saved with version 0.  This was mangling the odd offsets (they were being saved divided by two and read multiplied by two creating a off by one error)

Probably fixes https://github.com/bpampuch/pdfmake/issues/1659 and https://github.com/foliojs/pdfkit/issues/914
