### PR TITLE
Added `defaultLanguage` to font objects

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -88,13 +88,18 @@ export default class TTFFont {
    * The unique PostScript name for this font
    * @type {string}
    */
-  get postscriptName() {    
-    let name = this.name.records.postscriptName;
+  get postscriptName() {
+    let name = this.getName('postscriptName');
     if (name) {
-      let lang = Object.keys(name)[0];
-      return name[lang];
+      return name;
     }
-
+    
+    let record = this.name.records.postscriptName;
+    if (record) {
+      let lang = Object.keys(record)[0];
+      return record[lang];
+    }
+    
     return null;
   }
 

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -25,6 +25,7 @@ export default class TTFFont {
   }
 
   constructor(stream, variationCoords = null) {
+    this.defaultLanguage = 'en';
     this.stream = stream;
     this.variationCoords = variationCoords;
 
@@ -87,7 +88,7 @@ export default class TTFFont {
    * The unique PostScript name for this font
    * @type {string}
    */
-  get postscriptName() {
+  get postscriptName() {    
     let name = this.name.records.postscriptName;
     if (name) {
       let lang = Object.keys(name)[0];
@@ -102,7 +103,7 @@ export default class TTFFont {
    * `lang` is a BCP-47 language code.
    * @return {string}
    */
-  getName(key, lang = 'en') {
+  getName(key, lang = this.defaultLanguage) {
     let record = this.name.records[key];
     if (record) {
       return record[lang];


### PR DESCRIPTION
Setting the defaultLanguage allows you to overwrite the language returned by property getters like `fullName`, `familyName`, etc.
