### PR TITLE
Set a global default language

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -25,7 +25,7 @@ export default class TTFFont {
   }
 
   constructor(stream, variationCoords = null) {
-    this.defaultLanguage = fontkit.defaultLanguage;
+    this.defaultLanguage = null;
     this.stream = stream;
     this.variationCoords = variationCoords;
 
@@ -45,7 +45,7 @@ export default class TTFFont {
     }
   }
 
-  setDefaultLanguage(lang = fontkit.defaultLanguage) {
+  setDefaultLanguage(lang = null) {
     this.defaultLanguage = lang;
   }
 
@@ -112,7 +112,7 @@ export default class TTFFont {
    * `lang` is a BCP-47 language code.
    * @return {string}
    */
-  getName(key, lang = this.defaultLanguage) {
+  getName(key, lang = this.defaultLanguage || fontkit.defaultLanguage) {
     let record = this.name.records[key];
     if (record) {
       return record[lang];

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -25,7 +25,7 @@ export default class TTFFont {
   }
 
   constructor(stream, variationCoords = null) {
-    this.defaultLanguage = 'en';
+    this.defaultLanguage = fontkit.defaultLanguage;
     this.stream = stream;
     this.variationCoords = variationCoords;
 
@@ -43,6 +43,10 @@ export default class TTFFont {
         });
       }
     }
+  }
+
+  setDefaultLanguage(lang = fontkit.defaultLanguage) {
+    this.defaultLanguage = lang;
   }
 
   _getTable(table) {
@@ -93,13 +97,13 @@ export default class TTFFont {
     if (name) {
       return name;
     }
-    
+
     let record = this.name.records.postscriptName;
     if (record) {
       let lang = Object.keys(record)[0];
       return record[lang];
     }
-    
+
     return null;
   }
 

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -89,25 +89,6 @@ export default class TTFFont {
   }
 
   /**
-   * The unique PostScript name for this font
-   * @type {string}
-   */
-  get postscriptName() {
-    let name = this.getName('postscriptName');
-    if (name) {
-      return name;
-    }
-
-    let record = this.name.records.postscriptName;
-    if (record) {
-      let lang = Object.keys(record)[0];
-      return record[lang];
-    }
-
-    return null;
-  }
-
-  /**
    * Gets a string from the font's `name` table
    * `lang` is a BCP-47 language code.
    * @return {string}
@@ -115,10 +96,39 @@ export default class TTFFont {
   getName(key, lang = this.defaultLanguage || fontkit.defaultLanguage) {
     let record = this.name.records[key];
     if (record) {
-      return record[lang];
+      // Attempt to retrieve the entry, depending on which translations are available:
+
+      // Try the user-supplied language:
+      let result = record[lang];
+      // Try the font's default language:
+      if (!result && lang !== this.defaultLanguage) {
+        result = record[this.defaultLanguage];
+      }
+      // Try the global default language:
+      if (!result && lang !== fontkit.defaultLanguage) {
+        result = record[fontkit.defaultLanguage];
+      }
+      // Try English:
+      if (!result && lang !== 'en') {
+        result = record['en'];
+      }
+      // Seriously, ANY language would be fine:
+      if (!result) {
+        result = record[Object.keys(record)[0]];
+      }
+
+      return result;
     }
 
     return null;
+  }
+
+  /**
+   * The unique PostScript name for this font, e.g. "Helvetica-Bold"
+   * @type {string}
+   */
+  get postscriptName() {
+    return this.getName('postscriptName');
   }
 
   /**

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -94,30 +94,17 @@ export default class TTFFont {
    * @return {string}
    */
   getName(key, lang = this.defaultLanguage || fontkit.defaultLanguage) {
-    let record = this.name.records[key];
+    let record = this.name && this.name.records[key];
     if (record) {
-      // Attempt to retrieve the entry, depending on which translations are available:
-
-      // Try the user-supplied language:
-      let result = record[lang];
-      // Try the font's default language:
-      if (!result && lang !== this.defaultLanguage) {
-        result = record[this.defaultLanguage];
-      }
-      // Try the global default language:
-      if (!result && lang !== fontkit.defaultLanguage) {
-        result = record[fontkit.defaultLanguage];
-      }
-      // Try English:
-      if (!result && lang !== 'en') {
-        result = record['en'];
-      }
-      // Seriously, ANY language would be fine:
-      if (!result) {
-        result = record[Object.keys(record)[0]];
-      }
-
-      return result;
+      // Attempt to retrieve the entry, depending on which translation is available:
+      return (
+          record[lang]
+          || record[this.defaultLanguage]
+          || record[fontkit.defaultLanguage]
+          || record['en']
+          || record[Object.keys(record)[0]] // Seriously, ANY language would be fine
+          || null
+      );
     }
 
     return null;

--- a/src/base.js
+++ b/src/base.js
@@ -52,3 +52,8 @@ fontkit.create = function(buffer, postscriptName) {
 
   throw new Error('Unknown font format');
 };
+
+fontkit.defaultLanguage = 'en';
+fontkit.setDefaultLanguage = function(lang = 'en') {
+  fontkit.defaultLanguage = lang;
+};

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -4,13 +4,16 @@ import fontkit from '../src';
 
 describe('i18n', function() {
     describe('fontkit.setDefaultLanguage', function () {
-        after(function () {
+        let font;
+        before('load Amiri font', function() {
+            font = fontkit.openSync(__dirname + '/data/amiri/amiri-regular.ttf');
+        });
+        after('reset default language', function () {
             fontkit.setDefaultLanguage();
         });
 
-        it('has "en" metadata properties', function() {
-            let font = fontkit.openSync(__dirname + '/data/amiri/amiri-regular.ttf');
 
+        it('font has "en" metadata properties', function() {
             assert.equal(font.fullName, 'Amiri');
             assert.equal(font.postscriptName, 'Amiri-Regular');
             assert.equal(font.familyName, 'Amiri');
@@ -19,14 +22,12 @@ describe('i18n', function() {
             assert.equal(font.version, 'Version 000.110 ');
         });
 
-        it('can set default language to "ar"', function () {
+        it('can set global default language to "ar"', function () {
             fontkit.setDefaultLanguage('ar');
             assert.equal(fontkit.defaultLanguage, 'ar');
         });
 
-        it('has "ar" metadata properties', function() {
-            let font = fontkit.openSync(__dirname + '/data/amiri/amiri-regular.ttf');
-
+        it('font now has "ar" metadata properties', function() {
             assert.equal(font.fullName, undefined,);
             assert.equal(font.postscriptName, 'Amiri-Regular',);
             assert.equal(font.familyName, undefined,);
@@ -35,7 +36,7 @@ describe('i18n', function() {
             assert.equal(font.version, 'إصدارة 000٫110');
         });
 
-        it('can set default language back to "en"', function () {
+        it('can reset default language back to "en"', function () {
             fontkit.setDefaultLanguage();
             assert.equal(fontkit.defaultLanguage, "en");
         });
@@ -47,7 +48,7 @@ describe('i18n', function() {
             font = fontkit.openSync(__dirname + '/data/amiri/amiri-regular.ttf');
         });
 
-        it('has "en" metadata properties', function() {
+        it('font has "en" metadata properties', function() {
             assert.equal(font.fullName, 'Amiri');
             assert.equal(font.postscriptName, 'Amiri-Regular');
             assert.equal(font.familyName, 'Amiri');
@@ -56,9 +57,12 @@ describe('i18n', function() {
             assert.equal(font.version, 'Version 000.110 ');
         });
 
-        it('has "ar" metadata properties', function() {
+        it('can set font\'s default language to "ar"', function () {
             font.setDefaultLanguage('ar');
+            assert.equal(font.defaultLanguage, 'ar');
+        });
 
+        it('font now has "ar" metadata properties', function() {
             assert.equal(font.fullName, undefined,);
             assert.equal(font.postscriptName, 'Amiri-Regular',);
             assert.equal(font.familyName, undefined,);
@@ -67,10 +71,16 @@ describe('i18n', function() {
             assert.equal(font.version, 'إصدارة 000٫110');
         });
 
-        it('can set default language back to "en"', function () {
-            font.setDefaultLanguage();
-            assert.equal(font.defaultLanguage, "en");
+        it('the font\'s language should not change when the global changes', function () {
+            fontkit.setDefaultLanguage('en');
 
+            assert.equal(font.defaultLanguage, 'ar');
+            assert.equal(font.subfamilyName, 'عادي',);
+        });
+
+        it('can reset default language back to "en"', function () {
+            font.setDefaultLanguage();
+            assert.equal(font.defaultLanguage, null);
             assert.equal(font.subfamilyName, 'Regular');
         });
     });

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -28,11 +28,11 @@ describe('i18n', function() {
         });
 
         it('font now has "ar" metadata properties', function() {
-            assert.equal(font.fullName, undefined,);
-            assert.equal(font.postscriptName, 'Amiri-Regular',);
-            assert.equal(font.familyName, undefined,);
-            assert.equal(font.subfamilyName, 'عادي',);
-            assert.equal(font.copyright, 'حقوق النشر 2010-2017، خالد حسني <khaledhosny@eglug.org>.',);
+            assert.equal(font.fullName, 'Amiri');
+            assert.equal(font.postscriptName, 'Amiri-Regular');
+            assert.equal(font.familyName, 'Amiri');
+            assert.equal(font.subfamilyName, 'عادي');
+            assert.equal(font.copyright, 'حقوق النشر 2010-2017، خالد حسني <khaledhosny@eglug.org>.');
             assert.equal(font.version, 'إصدارة 000٫110');
         });
 
@@ -63,11 +63,11 @@ describe('i18n', function() {
         });
 
         it('font now has "ar" metadata properties', function() {
-            assert.equal(font.fullName, undefined,);
-            assert.equal(font.postscriptName, 'Amiri-Regular',);
-            assert.equal(font.familyName, undefined,);
-            assert.equal(font.subfamilyName, 'عادي',);
-            assert.equal(font.copyright, 'حقوق النشر 2010-2017، خالد حسني <khaledhosny@eglug.org>.',);
+            assert.equal(font.fullName, 'Amiri');
+            assert.equal(font.postscriptName, 'Amiri-Regular');
+            assert.equal(font.familyName, 'Amiri');
+            assert.equal(font.subfamilyName, 'عادي');
+            assert.equal(font.copyright, 'حقوق النشر 2010-2017، خالد حسني <khaledhosny@eglug.org>.');
             assert.equal(font.version, 'إصدارة 000٫110');
         });
 
@@ -75,12 +75,35 @@ describe('i18n', function() {
             fontkit.setDefaultLanguage('en');
 
             assert.equal(font.defaultLanguage, 'ar');
-            assert.equal(font.subfamilyName, 'عادي',);
+            assert.equal(font.subfamilyName, 'عادي');
         });
 
         it('can reset default language back to "en"', function () {
             font.setDefaultLanguage();
             assert.equal(font.defaultLanguage, null);
+            assert.equal(font.subfamilyName, 'Regular');
+        });
+    });
+
+    describe('backup languages', function () {
+        let font;
+        before('load Amiri font', function () {
+            font = fontkit.openSync(__dirname + '/data/amiri/amiri-regular.ttf');
+        });
+        after('reset default language', function () {
+            fontkit.setDefaultLanguage();
+        });
+
+        it('if the font\'s default language isn\'t found, use the global language', function () {
+            font.setDefaultLanguage('piglatin');
+            fontkit.setDefaultLanguage('ar');
+
+            assert.equal(font.subfamilyName, 'عادي');
+        });
+        it('if the global language isn\'t found, use "en"', function () {
+            font.setDefaultLanguage('piglatin');
+            fontkit.setDefaultLanguage('klingon');
+
             assert.equal(font.subfamilyName, 'Regular');
         });
     });

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -1,0 +1,77 @@
+import assert from 'assert';
+
+import fontkit from '../src';
+
+describe('i18n', function() {
+    describe('fontkit.setDefaultLanguage', function () {
+        after(function () {
+            fontkit.setDefaultLanguage();
+        });
+
+        it('has "en" metadata properties', function() {
+            let font = fontkit.openSync(__dirname + '/data/amiri/amiri-regular.ttf');
+
+            assert.equal(font.fullName, 'Amiri');
+            assert.equal(font.postscriptName, 'Amiri-Regular');
+            assert.equal(font.familyName, 'Amiri');
+            assert.equal(font.subfamilyName, 'Regular');
+            assert.equal(font.copyright, 'Copyright (c) 2010-2017, Khaled Hosny <khaledhosny@eglug.org>.\nPortions copyright (c) 2010, Sebastian Kosch <sebastian@aldusleaf.org>.');
+            assert.equal(font.version, 'Version 000.110 ');
+        });
+
+        it('can set default language to "ar"', function () {
+            fontkit.setDefaultLanguage('ar');
+            assert.equal(fontkit.defaultLanguage, 'ar');
+        });
+
+        it('has "ar" metadata properties', function() {
+            let font = fontkit.openSync(__dirname + '/data/amiri/amiri-regular.ttf');
+
+            assert.equal(font.fullName, undefined,);
+            assert.equal(font.postscriptName, 'Amiri-Regular',);
+            assert.equal(font.familyName, undefined,);
+            assert.equal(font.subfamilyName, 'عادي',);
+            assert.equal(font.copyright, 'حقوق النشر 2010-2017، خالد حسني <khaledhosny@eglug.org>.',);
+            assert.equal(font.version, 'إصدارة 000٫110');
+        });
+
+        it('can set default language back to "en"', function () {
+            fontkit.setDefaultLanguage();
+            assert.equal(fontkit.defaultLanguage, "en");
+        });
+    });
+
+    describe('font.setDefaultLanguage', function () {
+        let font;
+        before('load Amiri font', function () {
+            font = fontkit.openSync(__dirname + '/data/amiri/amiri-regular.ttf');
+        });
+
+        it('has "en" metadata properties', function() {
+            assert.equal(font.fullName, 'Amiri');
+            assert.equal(font.postscriptName, 'Amiri-Regular');
+            assert.equal(font.familyName, 'Amiri');
+            assert.equal(font.subfamilyName, 'Regular');
+            assert.equal(font.copyright, 'Copyright (c) 2010-2017, Khaled Hosny <khaledhosny@eglug.org>.\nPortions copyright (c) 2010, Sebastian Kosch <sebastian@aldusleaf.org>.');
+            assert.equal(font.version, 'Version 000.110 ');
+        });
+
+        it('has "ar" metadata properties', function() {
+            font.setDefaultLanguage('ar');
+
+            assert.equal(font.fullName, undefined,);
+            assert.equal(font.postscriptName, 'Amiri-Regular',);
+            assert.equal(font.familyName, undefined,);
+            assert.equal(font.subfamilyName, 'عادي',);
+            assert.equal(font.copyright, 'حقوق النشر 2010-2017، خالد حسني <khaledhosny@eglug.org>.',);
+            assert.equal(font.version, 'إصدارة 000٫110');
+        });
+
+        it('can set default language back to "en"', function () {
+            font.setDefaultLanguage();
+            assert.equal(font.defaultLanguage, "en");
+
+            assert.equal(font.subfamilyName, 'Regular');
+        });
+    });
+});


### PR DESCRIPTION
# What
- As a follow-up to https://github.com/foliojs/fontkit/pull/194, this PR enables a global `fontkit.setDefaultLanguage(lang)` method.  
- Fonts will use the global language property, unless you explicitly override it via `font.setDefaultLanguage(lang)`
- If a font property isn't available in the given language, it will attempt to find a backup language to use.  For example, it will look for `defaultLanguage`, then `"en"`, then just whatever is first.
- Additionally, unit tests were added for `fontkit.setDefaultLanguage` as well as `font.setDefaultLanguage`
