### PR TITLE
Augment AATMorxProcessor to allow for features to be disabled (instead of only enabled)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ Fontkit includes several methods for accessing glyph metrics and performing layo
 
 Returns the advance width (described above) for a single glyph id.
 
-#### `font.layout(string, features = [])`
+#### `font.layout(string, features = [] | {})`
 
 This method returns a `GlyphRun` object, which includes an array of `Glyph`s and `GlyphPosition`s for the given string.
 `Glyph` objects are described below. `GlyphPosition` objects include 4 properties: `xAdvance`, `yAdvance`, `xOffset`,
 and `yOffset`.
 
-The `features` parameter is an array of [OpenType feature tags](https://www.microsoft.com/typography/otspec/featuretags.htm) to be applied
-in addition to the default set. If this is an AAT font, the OpenType feature tags are mapped to AAT features.
+The `features` parameter is either an array of [OpenType feature tags](https://www.microsoft.com/typography/otspec/featuretags.htm) to be applied
+in addition to the default set, or an object mapping OpenType features to a boolean enabling or disabling each. If this is an AAT font, the OpenType feature tags are mapped to AAT features.
 
 ### Variation fonts
 

--- a/src/aat/AATMorxProcessor.js
+++ b/src/aat/AATMorxProcessor.js
@@ -44,7 +44,7 @@ export default class AATMorxProcessor {
   }
 
   // Processes an array of glyphs and applies the specified features
-  // Features should be in the form of {featureType:{featureSetting:true}}
+  // Features should be in the form of {featureType:{featureSetting:boolean}}
   process(glyphs, features = {}) {
     for (let chain of this.morx.chains) {
       let flags = chain.defaultFlags;
@@ -52,9 +52,14 @@ export default class AATMorxProcessor {
       // enable/disable the requested features
       for (let feature of chain.features) {
         let f;
-        if ((f = features[feature.featureType]) && f[feature.featureSetting]) {
-          flags &= feature.disableFlags;
-          flags |= feature.enableFlags;
+        if (f = features[feature.featureType]) {
+          if (f[feature.featureSetting]) {
+            flags &= feature.disableFlags;
+            flags |= feature.enableFlags;
+          } else if (f[feature.featureSetting] === false) {
+            flags |= ~feature.disableFlags;
+            flags &= ~feature.enableFlags;
+          }
         }
       }
 

--- a/test/glyph_mapping.js
+++ b/test/glyph_mapping.js
@@ -84,6 +84,13 @@ describe('character to glyph mapping', function() {
       return assert.deepEqual(glyphs.map(g => g.codePoints), [[102, 102, 105], [32], [49], [8260], [50]]);
     });
 
+    it('should allow for disabling of default AAT morx features', function() {
+      let {glyphs} = font.layout('ffi 1⁄2', { 'liga': false });
+      assert.equal(glyphs.length, 7);
+      assert.deepEqual(glyphs.map(g => g.id), [73, 73, 76, 3, 20, 645, 21]);
+      return assert.deepEqual(glyphs.map(g => g.codePoints), [[102], [102], [105], [32], [49], [8260], [50]]);
+    });
+
     it('should apply user specified features', function() {
       let {glyphs} = font.layout('ffi 1⁄2', [ 'numr' ]);
       assert.equal(glyphs.length, 3);


### PR DESCRIPTION
In a recent Chromium upgrade, ligatures were [disabled](https://bugs.chromium.org/p/chromium/issues/detail?id=896033&can=1&q=ligatures%20letter-spacing&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified) when letterspacing was non-zero. In order to match this behavior, we needed to add the ability to disable default AAT morx features.

I've added a test for this case and validated it does allow us to disable ligatures with non-zero letterspacing but I'm not a font expert and want to validate this won't introduce any issues.

Here's a snippet

```typescript
let glyphRun;
if (characterSpacing === 0) {
   glyphRun = fontkitFont.layout(text);
} else {
   glyphRun = fontkitFont.layout(text, { liga: false });
}
```

and the resulting output 

![image](https://user-images.githubusercontent.com/44379112/65081861-33c7be80-d96a-11e9-844c-1cab954f50d7.png)

