### PR TITLE
Update restructure to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "clone": "^1.0.4",
     "deep-equal": "^1.0.0",
     "dfa": "^1.2.0",
-    "restructure": "^0.5.3",
+    "restructure": "^2.0.0",
     "tiny-inflate": "^1.0.2",
     "unicode-properties": "^1.2.2",
     "unicode-trie": "^0.3.0"

--- a/src/tables/GPOS.js
+++ b/src/tables/GPOS.js
@@ -14,10 +14,10 @@ let types = {
   yPlacement: r.int16,
   xAdvance:   r.int16,
   yAdvance:   r.int16,
-  xPlaDevice: new r.Pointer(r.uint16, Device, { type: 'global', relativeTo: 'rel' }),
-  yPlaDevice: new r.Pointer(r.uint16, Device, { type: 'global', relativeTo: 'rel' }),
-  xAdvDevice: new r.Pointer(r.uint16, Device, { type: 'global', relativeTo: 'rel' }),
-  yAdvDevice: new r.Pointer(r.uint16, Device, { type: 'global', relativeTo: 'rel' })
+  xPlaDevice: new r.Pointer(r.uint16, Device, { type: 'global', relativeTo: ctx => ctx.rel }),
+  yPlaDevice: new r.Pointer(r.uint16, Device, { type: 'global', relativeTo: ctx => ctx.rel }),
+  xAdvDevice: new r.Pointer(r.uint16, Device, { type: 'global', relativeTo: ctx => ctx.rel }),
+  yAdvDevice: new r.Pointer(r.uint16, Device, { type: 'global', relativeTo: ctx => ctx.rel })
 };
 
 class ValueRecord {

--- a/src/tables/gvar.js
+++ b/src/tables/gvar.js
@@ -6,7 +6,7 @@ class Offset {
     // In short format, offsets are multiplied by 2.
     // This doesn't seem to be documented by Apple, but it
     // is implemented this way in Freetype.
-    return parent.flags 
+    return parent.flags
       ? stream.readUInt32BE()
       : stream.readUInt16BE() * 2;
   }
@@ -21,7 +21,7 @@ let gvar = new r.Struct({
   glyphCount: r.uint16,
   flags: r.uint16,
   offsetToData: r.uint32,
-  offsets: new r.Array(new r.Pointer(Offset, 'void', { relativeTo: 'offsetToData', allowNull: false }), t => t.glyphCount + 1)
+  offsets: new r.Array(new r.Pointer(Offset, 'void', { relativeTo: ctx => ctx.offsetToData, allowNull: false }), t => t.glyphCount + 1)
 });
 
 export default gvar;

--- a/src/tables/just.js
+++ b/src/tables/just.js
@@ -70,7 +70,7 @@ let JustificationTable = new r.Struct({
   classTable: new r.Pointer(r.uint16, ClassTable, { type: 'parent' }),
   wdcOffset: r.uint16,
   postCompensationTable: new r.Pointer(r.uint16, PostCompensationTable, { type: 'parent' }),
-  widthDeltaClusters: new LookupTable(new r.Pointer(r.uint16, WidthDeltaCluster, { type: 'parent', relativeTo: 'wdcOffset' }))
+  widthDeltaClusters: new LookupTable(new r.Pointer(r.uint16, WidthDeltaCluster, { type: 'parent', relativeTo: ctx => ctx.wdcOffset }))
 });
 
 export default new r.Struct({

--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -9,13 +9,13 @@ let NameRecord = new r.Struct({
   length:     r.uint16,
   string:     new r.Pointer(r.uint16,
     new r.String('length', t => getEncoding(t.platformID, t.encodingID, t.languageID)),
-    { type: 'parent', relativeTo: 'parent.stringOffset', allowNull: false }
+    { type: 'parent', relativeTo: ctx => ctx.parent.stringOffset, allowNull: false }
   )
 });
 
 let LangTagRecord = new r.Struct({
   length:  r.uint16,
-  tag:     new r.Pointer(r.uint16, new r.String('length', 'utf16be'), {type: 'parent', relativeTo: 'stringOffset'})
+  tag:     new r.Pointer(r.uint16, new r.String('length', 'utf16be'), {type: 'parent', relativeTo: ctx => ctx.stringOffset})
 });
 
 var NameTable = new r.VersionedStruct(r.uint16, {


### PR DESCRIPTION
PR updated restructure to version 2.

Before merge is required:
- update babel - PR https://github.com/foliojs/fontkit/pull/196

Before release fonkit version for avoid CSP:
- release a new [restructure](https://github.com/foliojs/restructure) version with `new Function` fix (https://github.com/foliojs/restructure/pull/37)

@devongovett You can look at it?