### PR TITLE
Changed sinh's shaper into IndicShaper

### DIFF
--- a/src/opentype/shapers/index.js
+++ b/src/opentype/shapers/index.js
@@ -69,7 +69,7 @@ const SHAPERS = {
   saur: UniversalShaper, // Saurashtra
   shrd: UniversalShaper, // Sharada
   sidd: UniversalShaper, // Siddham
-  sinh: UniversalShaper, // Sinhala
+  sinh: IndicShaper, // Sinhala
   sund: UniversalShaper, // Sundanese
   sylo: UniversalShaper, // Syloti Nagri
   tglg: UniversalShaper, // Tagalog


### PR DESCRIPTION
Solved the "Type Error: Cannot read property 'syllable' of null" when a pdfmake document contains certain the characters \u0dda and \u0ddd. 

Reference: https://stackoverflow.com/questions/60056226/is-there-anyway-to-bypass-this-error-on-pdfmake-type-error-cannot-read-proper