### PR TITLE
Added featureParams for friendly stylistic set names

### DIFF
--- a/src/tables/opentype.js
+++ b/src/tables/opentype.js
@@ -33,8 +33,13 @@ export let ScriptList = new r.Array(ScriptRecord, r.uint16);
 // Features and Lookups #
 //#######################
 
+let FeatureParams = new r.Struct({
+  version:    r.uint16, // should be set to 0 according OT spec
+  nameID:     r.uint16, //OT spec: UI Name ID or uiLabelNameId
+});
+
 export let Feature = new r.Struct({
-  featureParams:      r.uint16, // pointer
+  featureParams:      0 === r.uint16 ? 0 : new r.Pointer(r.uint16, FeatureParams),
   lookupCount:        r.uint16,
   lookupListIndexes:  new r.Array(r.uint16, 'lookupCount')
 });

--- a/src/tables/opentype.js
+++ b/src/tables/opentype.js
@@ -39,7 +39,7 @@ let FeatureParams = new r.Struct({
 });
 
 export let Feature = new r.Struct({
-  featureParams:      0 === r.uint16 ? 0 : new r.Pointer(r.uint16, FeatureParams),
+  featureParams:      new r.Pointer(r.uint16, FeatureParams),
   lookupCount:        r.uint16,
   lookupListIndexes:  new r.Array(r.uint16, 'lookupCount')
 });

--- a/test/opentype.js
+++ b/test/opentype.js
@@ -1,0 +1,15 @@
+import fontkit from '../src';
+import assert from 'assert';
+
+describe('opentype', function() {
+  let font = fontkit.openSync(__dirname + '/data/SourceSansPro/SourceSansPro-Regular.otf');
+
+  it('Should get featureParams nameID of stylistic set', function() {
+    assert.equal(font.GSUB.featureList[150].feature.featureParams.nameID, 257);
+  });
+
+  it('featureParams should be null of aalt opentype feature', function() {
+    assert.equal(font.GSUB.featureList[1].feature.featureParams, null);
+  });
+
+});

--- a/test/opentype.js
+++ b/test/opentype.js
@@ -4,8 +4,12 @@ import assert from 'assert';
 describe('opentype', function() {
   let font = fontkit.openSync(__dirname + '/data/SourceSansPro/SourceSansPro-Regular.otf');
 
-  it('Should get featureParams nameID of stylistic set', function() {
+  it('featureParams nameID of stylistic set should be 257', function() {
     assert.equal(font.GSUB.featureList[150].feature.featureParams.nameID, 257);
+  });
+
+  it('featureParams version of stylistic set should be 0', function() {
+    assert.equal(font.GSUB.featureList[150].feature.featureParams.version, 0);
   });
 
   it('featureParams should be null of aalt opentype feature', function() {


### PR DESCRIPTION
Added featureParams to get friendly stylistic set name via given nameID if given. 
For reference, see OT spec: https://docs.microsoft.com/en-us/typography/opentype/spec/features_pt#tag-ss01---ss20