### PR TITLE
Support Buffer postscriptName

### DIFF
--- a/src/DFont.js
+++ b/src/DFont.js
@@ -87,9 +87,8 @@ export default class DFont {
       let pos = this.header.dataOffset + ref.dataOffset + 4;
       let stream = new r.DecodeStream(this.stream.buffer.slice(pos));
       let font = new TTFFont(stream);
-      if (font.postscriptName === name) {
+      if ((Buffer.isBuffer(font.postscriptName) && font.postscriptName.equals(name)) || font.postscriptName === name)
         return font;
-      }
     }
 
     return null;

--- a/src/TrueTypeCollection.js
+++ b/src/TrueTypeCollection.js
@@ -36,9 +36,8 @@ export default class TrueTypeCollection {
       let stream = new r.DecodeStream(this.stream.buffer);
       stream.pos = offset;
       let font = new TTFFont(stream);
-      if (font.postscriptName === name) {
+      if ((Buffer.isBuffer(font.postscriptName) && font.postscriptName.equals(name)) || font.postscriptName === name)
         return font;
-      }
     }
 
     return null;


### PR DESCRIPTION
When using a .dfont on macOS (11.6), it seems like the postscriptName is of type Buffer instead of string, which leads to getFont failing and logging that an incorrect font is being used.

This is more of a workaround as ideally, the font's postscriptName should be consistent.