### PR TITLE
`phase` variable scope issue

### DIFF
--- a/src/glyph/CFFGlyph.js
+++ b/src/glyph/CFFGlyph.js
@@ -320,8 +320,8 @@ export default class CFFGlyph extends Glyph {
               break;
 
             case 30: // vhcurveto
-            case 31: // hvcurveto
-              phase = op === 31;
+            case 31: { // hvcurveto
+              let phase = op === 31;
               while (stack.length >= 4) {
                 if (phase) {
                   c1x = x + stack.shift();
@@ -343,6 +343,7 @@ export default class CFFGlyph extends Glyph {
                 phase = !phase;
               }
               break;
+            }
 
             case 12:
               op = stream.readUInt8();


### PR DESCRIPTION
For case 31, you get an reference error "Cannot access 'phase' before initialization" even though it is declared in case 7.