### PR TITLE
fix Path.transform breaks Path rotation #268

### DIFF
--- a/src/glyph/Path.js
+++ b/src/glyph/Path.js
@@ -201,9 +201,9 @@ export default class Path {
    */
   transform(m0, m1, m2, m3, m4, m5) {
     return this.mapPoints((x, y) => {
-      x = m0 * x + m2 * y + m4;
-      y = m1 * x + m3 * y + m5;
-      return [x, y];
+      const tx = m0 * x + m2 * y + m4;
+      const ty = m1 * x + m3 * y + m5;
+      return [tx, ty];
     });
   }
 


### PR DESCRIPTION
This prevents the use of the transformed x instead of the original x when computing the transformed y.