### PR TITLE
Fix the Variation Selector handling

### DIFF
--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -156,15 +156,21 @@ export default class CmapProcessor {
 
     let selectors = this.uvs.varSelectors.toArray();
     let i = binarySearch(selectors, x => variationSelector - x.varSelector);
+    if (i === -1) {
+      return 0;
+    }
     let sel = selectors[i];
 
-    if (i !== -1 && sel.defaultUVS) {
+    if (sel.defaultUVS) {
       i = binarySearch(sel.defaultUVS, x =>
         codepoint < x.startUnicodeValue ? -1 : codepoint > x.startUnicodeValue + x.additionalCount ? +1 : 0
       );
+      if (i !== -1) {
+        return 0;
+      }
     }
 
-    if (i !== -1 && sel.nonDefaultUVS) {
+    if (sel.nonDefaultUVS) {
       i = binarySearch(sel.nonDefaultUVS, x => codepoint - x.unicodeValue);
       if (i !== -1) {
         return sel.nonDefaultUVS[i].glyphID;


### PR DESCRIPTION
Fix the problem that the variable `i` was overwritten and the non-default UVS wasn't used when the default UVS exists.