### PR TITLE
Make fontkit work in the browser

### DIFF
--- a/fs.cjs
+++ b/fs.cjs
@@ -1,0 +1,5 @@
+// This is a workaround to make it work in the browser where the 'fs'
+// module does not exists.
+try {
+  module.exports = require('fs');
+} catch (err) { }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.3.13",
-        "brotli": "^1.3.2",
+        "brotli": "^1.3.3",
         "clone": "^2.1.2",
         "deep-equal": "^2.0.5",
         "dfa": "^1.2.0",
@@ -1838,9 +1838,9 @@
       }
     },
     "node_modules/brotli": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
-      "integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
       "dependencies": {
         "base64-js": "^1.1.2"
       }
@@ -6373,9 +6373,9 @@
       }
     },
     "brotli": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
-      "integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
       "requires": {
         "base64-js": "^1.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "files": [
     "src",
     "dist",
-    "iconv-lite.cjs"
+    "iconv-lite.cjs",
+    "fs.cjs"
   ],
   "author": "Devon Govett <devongovett@gmail.com>",
   "license": "MIT",
@@ -70,6 +71,7 @@
     "shx": "^0.3.4"
   },
   "alias": {
-    "./iconv-lite.cjs": "clone"
+    "./iconv-lite.cjs": "clone",
+    "./fs.cjs": "clone"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@swc/helpers": "^0.3.13",
-    "brotli": "^1.3.2",
+    "brotli": "^1.3.3",
     "clone": "^2.1.2",
     "deep-equal": "^2.0.5",
     "dfa": "^1.2.0",

--- a/src/base.js
+++ b/src/base.js
@@ -1,5 +1,5 @@
 import r from 'restructure';
-const fs = require('fs');
+import fs from '../fs.cjs';
 
 export let logErrors = false;
 


### PR DESCRIPTION
This change is a step forward to make fontkit fully compatible out of the box in the browser (tested with nuxt/webpack 4).

Edit: with the update to brotli:1.3.3 this is fully working in the browser when using a bundler.