### PR TITLE
Drop node dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ let buffer = subset.encode();
 
 ## API
 
-### `fontkit.open(filename, postscriptName = null, callback(err, font))`
+### `fontkit.open(filename, postscriptName = null)`
 
-Opens a font file asynchronously, and calls the callback with a font object. For collection fonts (such as TrueType collection files), you can pass a `postscriptName` to get that font out of the collection instead of a collection object.
+Opens a font file asynchronously, and returns a `Promise` with a font object. For collection fonts (such as TrueType collection files), you can pass a `postscriptName` to get that font out of the collection instead of a collection object.
 
 ### `fontkit.openSync(filename, postscriptName = null)`
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ run.glyphs.forEach(function(glyph) {
   subset.includeGlyph(glyph);
 });
 
-subset.encodeStream()
-      .pipe(fs.createWriteStream('subset.ttf'));
+let buffer = subset.encode();
 ```
 
 ## API
@@ -258,9 +257,9 @@ You create a Subset object by calling `font.createSubset()`, described above. Th
 
 Includes the given glyph object or glyph ID in the subset.
 
-### `subset.encodeStream()`
+### `subset.encode()`
 
-Returns a [stream](https://nodejs.org/api/stream.html) containing the encoded font file that can be piped to a destination, such as a file.
+Returns a `Uint8Array` containing the encoded font file.
 
 ## License
 

--- a/iconv-lite.cjs
+++ b/iconv-lite.cjs
@@ -1,7 +1,0 @@
-// iconv-lite is an optional dependency.
-// This is a hack to make that work with Node native ESM by creating a CJS module
-// that can be imported from ESM. This also works in bundlers which support try..catch
-// blocks to mark optional dependencies.
-try {
-  module.exports = require('iconv-lite');
-} catch (err) { }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
-        "@swc/helpers": "^0.3.13",
+        "@swc/helpers": "^0.4.2",
         "brotli": "^1.3.2",
         "clone": "^2.1.2",
         "deep-equal": "^2.0.5",
@@ -23,10 +23,9 @@
         "c8": "^7.11.3",
         "codepoints": "^1.2.0",
         "concat-stream": "^2.0.0",
-        "iconv-lite": "^0.4.24",
         "mocha": "^10.0.0",
         "npm-run-all": "^4.1.5",
-        "parcel": "^2.5.0",
+        "parcel": "^2.6.1",
         "shx": "^0.3.4"
       }
     },
@@ -80,6 +79,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
+      "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
@@ -87,6 +100,25 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -120,6 +152,84 @@
         "@lezer/common": "^0.15.0"
       }
     },
+    "node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@mischnic/json-sourcemap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
@@ -135,20 +245,20 @@
       }
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.5.0.tgz",
-      "integrity": "sha512-7CJzE17SirCXjcRgBcnqWO/5EOA1raq/3OIKtT4cxbjpDQGHZpjpEEZiMNRpEpdNMxDSlsG8mAkXTYGL2VVWRw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.6.1.tgz",
+      "integrity": "sha512-hCaLnvanoQcWp+09WGdo3q1/qrqLuwgoWf3wU5IrQgx77JqnASBTn0/qkEes5vNH0VbHDWmwtPSoECPLWxNS/A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -156,15 +266,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.1.tgz",
+      "integrity": "sha512-FjG9DDLUCxlnS32cF7riga8gwMKbwxKnVIUsKZU5K9I+Sd5HtKRqn8H3e7dksCiVCPqZR3jItnr7FH9bEniWJA==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "lmdb": "2.2.4"
+        "@parcel/fs": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "lmdb": "2.5.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -174,13 +284,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.1"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
-      "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.1.tgz",
+      "integrity": "sha512-6GR9w9cccxCMbDqXNfEGwFjju+Ks3mMDaiLuLXIITkuEYgxdbXrpNlcpD0tJiSJn3cyo8gieUYFF4wlJyuS/gQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -264,16 +374,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.5.0.tgz",
-      "integrity": "sha512-I5Zs+2f1ue4sTPdfT8BNsLfTZl48sMWLk2Io3elUJjH/SS9kO7ut5ChkuJtt77ZS35m0OF+ZCt3ICTJdnDG8eA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.6.1.tgz",
+      "integrity": "sha512-UbA1xndQHZVWXdkVN/3PH0libsB6M1urEvTOrtxXiZS4bVGqj/UwoZ47OZA92ls0q35Qa0tWjQ6zBmlrgRWCsg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -281,70 +391,70 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.5.0.tgz",
-      "integrity": "sha512-r30V61958SONvP9I8KV8s44ZOFq0H219VyFjPysraSabHjZ+KMaCTQOuqaDtUMa272sHUQkBcZxKYj5jYPJlZg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.6.1.tgz",
+      "integrity": "sha512-upW4K2fdljpcHhmniEGVdBjqonFUqfONMWnxrS3WEikcuCwr2/IVLD61w0MPLEeu8Xbr2anHJwh2/kl7DiWDZQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.5.0",
-        "@parcel/compressor-raw": "2.5.0",
-        "@parcel/namer-default": "2.5.0",
-        "@parcel/optimizer-css": "2.5.0",
-        "@parcel/optimizer-htmlnano": "2.5.0",
-        "@parcel/optimizer-image": "2.5.0",
-        "@parcel/optimizer-svgo": "2.5.0",
-        "@parcel/optimizer-terser": "2.5.0",
-        "@parcel/packager-css": "2.5.0",
-        "@parcel/packager-html": "2.5.0",
-        "@parcel/packager-js": "2.5.0",
-        "@parcel/packager-raw": "2.5.0",
-        "@parcel/packager-svg": "2.5.0",
-        "@parcel/reporter-dev-server": "2.5.0",
-        "@parcel/resolver-default": "2.5.0",
-        "@parcel/runtime-browser-hmr": "2.5.0",
-        "@parcel/runtime-js": "2.5.0",
-        "@parcel/runtime-react-refresh": "2.5.0",
-        "@parcel/runtime-service-worker": "2.5.0",
-        "@parcel/transformer-babel": "2.5.0",
-        "@parcel/transformer-css": "2.5.0",
-        "@parcel/transformer-html": "2.5.0",
-        "@parcel/transformer-image": "2.5.0",
-        "@parcel/transformer-js": "2.5.0",
-        "@parcel/transformer-json": "2.5.0",
-        "@parcel/transformer-postcss": "2.5.0",
-        "@parcel/transformer-posthtml": "2.5.0",
-        "@parcel/transformer-raw": "2.5.0",
-        "@parcel/transformer-react-refresh-wrap": "2.5.0",
-        "@parcel/transformer-svg": "2.5.0"
+        "@parcel/bundler-default": "2.6.1",
+        "@parcel/compressor-raw": "2.6.1",
+        "@parcel/namer-default": "2.6.1",
+        "@parcel/optimizer-css": "2.6.1",
+        "@parcel/optimizer-htmlnano": "2.6.1",
+        "@parcel/optimizer-image": "2.6.1",
+        "@parcel/optimizer-svgo": "2.6.1",
+        "@parcel/optimizer-terser": "2.6.1",
+        "@parcel/packager-css": "2.6.1",
+        "@parcel/packager-html": "2.6.1",
+        "@parcel/packager-js": "2.6.1",
+        "@parcel/packager-raw": "2.6.1",
+        "@parcel/packager-svg": "2.6.1",
+        "@parcel/reporter-dev-server": "2.6.1",
+        "@parcel/resolver-default": "2.6.1",
+        "@parcel/runtime-browser-hmr": "2.6.1",
+        "@parcel/runtime-js": "2.6.1",
+        "@parcel/runtime-react-refresh": "2.6.1",
+        "@parcel/runtime-service-worker": "2.6.1",
+        "@parcel/transformer-babel": "2.6.1",
+        "@parcel/transformer-css": "2.6.1",
+        "@parcel/transformer-html": "2.6.1",
+        "@parcel/transformer-image": "2.6.1",
+        "@parcel/transformer-js": "2.6.1",
+        "@parcel/transformer-json": "2.6.1",
+        "@parcel/transformer-postcss": "2.6.1",
+        "@parcel/transformer-posthtml": "2.6.1",
+        "@parcel/transformer-raw": "2.6.1",
+        "@parcel/transformer-react-refresh-wrap": "2.6.1",
+        "@parcel/transformer-svg": "2.6.1"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.1"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-dygDmPsfAYJKTnUftcbEzjCik7AAaPbFvJW8ETYz8diyjkAG9y6hvCAZIrJE5pNOjFzg32en4v4UWv8Sqlzl9g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-FcinQQEtqqb0cSj4JPD8vx/qMkz1rWdbxtdEPG0W1cA2I5qcVPMgkHsVFrDnWQlQIquwu98um8zg1MrN1KrRew==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/graph": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/cache": "2.6.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/events": "2.6.1",
+        "@parcel/fs": "2.6.1",
+        "@parcel/graph": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/package-manager": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "@parcel/workers": "2.6.1",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -365,9 +475,9 @@
       }
     },
     "node_modules/@parcel/css": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.8.3.tgz",
-      "integrity": "sha512-6qUN4iicr8f9Q6UUZttwwHMzrb65BRX46PHWq0icA4KEmvmfR9cSYlp/hJH8F4stg3Wncx12Bnw+EuPf5OAEPQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.10.1.tgz",
+      "integrity": "sha512-qnoQM4qH6ytYE3RK8PzMoI8dGPmJv/fNFkeC8Ku0A08GbG/ssir2TCQCarcKFVNgvtfDZ0AX3+vjSkYEAfzhJA==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -380,20 +490,20 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/css-darwin-arm64": "1.8.3",
-        "@parcel/css-darwin-x64": "1.8.3",
-        "@parcel/css-linux-arm-gnueabihf": "1.8.3",
-        "@parcel/css-linux-arm64-gnu": "1.8.3",
-        "@parcel/css-linux-arm64-musl": "1.8.3",
-        "@parcel/css-linux-x64-gnu": "1.8.3",
-        "@parcel/css-linux-x64-musl": "1.8.3",
-        "@parcel/css-win32-x64-msvc": "1.8.3"
+        "@parcel/css-darwin-arm64": "1.10.1",
+        "@parcel/css-darwin-x64": "1.10.1",
+        "@parcel/css-linux-arm-gnueabihf": "1.10.1",
+        "@parcel/css-linux-arm64-gnu": "1.10.1",
+        "@parcel/css-linux-arm64-musl": "1.10.1",
+        "@parcel/css-linux-x64-gnu": "1.10.1",
+        "@parcel/css-linux-x64-musl": "1.10.1",
+        "@parcel/css-win32-x64-msvc": "1.10.1"
       }
     },
     "node_modules/@parcel/css-darwin-arm64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.8.3.tgz",
-      "integrity": "sha512-qh/Ig6GfVjGoiGSWjIYDo6Ghwmyy/9BXvYS1l3R+Bp50F300cq84Czfl6wxaL+aFmghdHzhjJuGfWmZlcYliPA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.10.1.tgz",
+      "integrity": "sha512-0ukr4/hSrM24ef8bcZ5b/o8iJrPVAxXOKCPGpmKFd+R/31SYjvFfMJzS2XAYUy0W0FunMW2fte3iTPNMDigyww==",
       "cpu": [
         "arm64"
       ],
@@ -411,9 +521,9 @@
       }
     },
     "node_modules/@parcel/css-darwin-x64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.8.3.tgz",
-      "integrity": "sha512-gTUIoRgwyYr4UuH7sSn3gOuMlIshJBOJLmjL+E/mR5lqdYabguiKiRORvkrnb/gHBmOUF9re0RcTaFmJ2VOAlg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.10.1.tgz",
+      "integrity": "sha512-PFMPptY+OswU68XgBO2RlL6JckeWz/a36r7ys6LMPrNonIOWGce155lwnylBK1Pnx1DRQAN8jWaolo+OkD9RRQ==",
       "cpu": [
         "x64"
       ],
@@ -431,9 +541,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm-gnueabihf": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.8.3.tgz",
-      "integrity": "sha512-4P1r0BvL9dPz70py2xLg/jEvWJmKNyokPgafyrDP+GbpPTfH5NYJJkVRGo/TkKsp3Rv8SJhV9fdlpFKC6BI92A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.10.1.tgz",
+      "integrity": "sha512-QICiX10CDudilEV+DUBKbbJb7ckSuj2hyI3NyzphRqkxBE7t4Hb04x6RPKITEJwHgvqUQ3OUPWyvtalVAi36Ww==",
       "cpu": [
         "arm"
       ],
@@ -451,9 +561,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm64-gnu": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.8.3.tgz",
-      "integrity": "sha512-1fUy94eaqdzum+C7bsYVF2AgxjLGR/qppArn/4HTQyydHR5QeV+Uoyqo5vdnO5Vclj8eQwlgR9OyAOlmzXxFDA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.10.1.tgz",
+      "integrity": "sha512-dHaQiBXlrDPdqE8O1qnlYqp1N9la1jgcYgIUCtm4NkNltzLVbbSFXyeG7OXeT6njP6ltMb4mmEFL18I2Wr3l3A==",
       "cpu": [
         "arm64"
       ],
@@ -471,9 +581,9 @@
       }
     },
     "node_modules/@parcel/css-linux-arm64-musl": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.8.3.tgz",
-      "integrity": "sha512-ct1QRK5gAP8sO22NZ7RULZQB7dbHpou+WMa4z0LJb+Fho13a1JNw931vNHbeI5cRr1fCTDq76pz/+Valgetzcw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.10.1.tgz",
+      "integrity": "sha512-inBbDCGhJaZcNCb588wQz5tYpGbnz8W/g9aFOH6X3nSBNToknOHplBHjOMLOB7vBxAykNjbywaNtE5H9qoY0/A==",
       "cpu": [
         "arm64"
       ],
@@ -491,9 +601,9 @@
       }
     },
     "node_modules/@parcel/css-linux-x64-gnu": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.8.3.tgz",
-      "integrity": "sha512-pg/mahoogzjbaZcW76rrTZ64tEu8Wok4Gm0sW/dXHJEJD2QVJ6GxLP4UVNBuhaV0GrNFHggp9pcdhTtLGkKl/g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.10.1.tgz",
+      "integrity": "sha512-gBaHgMXom1lCGu/ummD1wqknxF9ZKFBUlxQ/0DtCdOtZlRBEKeWtoskK9tgH4YMnwTpMIagCwWB4UbP/9Yzz6A==",
       "cpu": [
         "x64"
       ],
@@ -511,9 +621,9 @@
       }
     },
     "node_modules/@parcel/css-linux-x64-musl": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.8.3.tgz",
-      "integrity": "sha512-4Iwawy28HQ2yAgbuyR60bgO+8oE+OiWpE02eNjbgqnDpTsfmXFMt4l5OYgZwJJ7DlaZqm+/yO8RPMd+EzwtNzg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.10.1.tgz",
+      "integrity": "sha512-arjLARo/3l0uwPf5qYxCkrS0FTE8n6JH/S1/7DitvhG22fsZdJTGPwe4MYLTIn4s3QXLOVVRrkPDZlUPM1yjFA==",
       "cpu": [
         "x64"
       ],
@@ -531,9 +641,9 @@
       }
     },
     "node_modules/@parcel/css-win32-x64-msvc": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.8.3.tgz",
-      "integrity": "sha512-vnHUdzIVjqONa5ALFzMJ3ZHt6NiaYTHW/lqzP+AR4l+bq+UTXD2Q75/RgirY5NYwdfy1VPy/jI82jAtLOCymkw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.10.1.tgz",
+      "integrity": "sha512-f/jkhL2uOZCHJg3/IGcuieZ4TTwkxExLd7SWVuiqJZI2nwOy/gLHTZJz3yzu/D1aLOe0M9/glgzUKRtK0DrUNA==",
       "cpu": [
         "x64"
       ],
@@ -551,9 +661,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
-      "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.1.tgz",
+      "integrity": "sha512-7lbmRCHEeS8uzO+BzfTtiJMfeOKf5HOTaVE+kzTkfqHT/H3ChD1rNQQdxTjE+TvX2k7lLdEE6Qstj7OmrE/xQg==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -568,9 +678,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
-      "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.1.tgz",
+      "integrity": "sha512-x0PkTFm2wm1hIfwD/p0jNuCUM0t2NwzUxdZrTHm9ncqrYbO2tpG0N5jkTC9V9fu7j639vGVA7uOHYFgExTKUbQ==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -581,16 +691,16 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
-      "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.1.tgz",
+      "integrity": "sha512-+kI2IPdZ5WH94+9LMCO/INnJUcbPcfVim97ORMjfe3mOYEPEQYqzM5g8SLjqiW/H5OIVapdIYoHWBEBpo3itdA==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs-search": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/fs-search": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.5.0"
+        "@parcel/workers": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -600,13 +710,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.1"
       }
     },
     "node_modules/@parcel/fs-search": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
-      "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.1.tgz",
+      "integrity": "sha512-vfbknvzUjy1PQuCfjfbCQUIQXCUb+n+sd5CZHOODvE4PewvspW/YmKJpYluDr0S4mOa1GX7cHJCL675DALW5yQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -620,12 +730,12 @@
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.5.0.tgz",
-      "integrity": "sha512-qa2VtG08dJyTaWrxYAkMIlkoDRSPoiqLDNxxHKplkcxAjXBUw0/AkWaz82VO5r1G6jfOj+nM30ajH9uygZYwbw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.1.tgz",
+      "integrity": "sha512-tzv9P3hyS9SZiwmE6KB1ZFhXV3/vjFNZV7+XGbf1opI3oTwawBb+XaH4k7InPyVYZTo1QrlauhoP+EQZFyzPEQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -637,9 +747,9 @@
       }
     },
     "node_modules/@parcel/hash": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
-      "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.1.tgz",
+      "integrity": "sha512-5gve/OKOXzYADfCJ+atpR6L13n4clexazkNRcsm6LZtE2Gm84Nx81gdb8z08EJrZALC62f9J2FOmQxm6ZHrTSQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -654,13 +764,13 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
-      "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.1.tgz",
+      "integrity": "sha512-AnKAVS/QRi1ee+Q1MxL+oUZT7dBZ36VUtevmXMSaaoN3W1KwYjM4Brq3zdiTZRfa7Akpdu6Ca1QVK5hGpvXKSg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0"
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/events": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -671,9 +781,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
-      "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.1.tgz",
+      "integrity": "sha512-p4dDINi+UeEUQfkA70R9gNJIuSnMuljSUfHf7erTU8vSqRD1tQpnmH7GfzzQLHYwHk8UYICGU8C6z7EtPH92Ng==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -757,18 +867,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
-      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.1.tgz",
+      "integrity": "sha512-J7KajS6s0GvpZ0YIN8t/Z4Go/E7tS136bKyvSdWhVOUosmt2pW1L20lq9KfPVYDvWQNu12jqJbAHQFsqOLyllw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -776,14 +886,15 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.5.0.tgz",
-      "integrity": "sha512-XQvpguiIwQcu75cscLDFOVhjsjuPzXbuMaaZ7XxxUEl0PscIgu/GfKYxTfTruN3cRl+CaQH6qBAMfjLaFng6lQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.6.1.tgz",
+      "integrity": "sha512-LaLiJkgr5Cq9ue5wxsFR97S3R+IOGkmvivNsdc4Y9Gdj9WO1nMTaNMBlw+AIjtbzdbw0MUvKQik2tR4AmfBcLw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "nullthrows": "^1.1.1"
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -794,22 +905,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.5.0.tgz",
-      "integrity": "sha512-J00bLF+4SsnKc+YbYrNuBr44/zz3cg++CoXteXhH27PxP1rScGQx36Rui8WORgil5mlX2VYN79DuqJC7V3Ynbg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.6.1.tgz",
+      "integrity": "sha512-VNdATqH068XCbzaOBbgdZOBJAMomkXOqcmxXOmQkHqTKqBO11xXLIESP+PQwTXoxy7If+2ufxOPCHTI20691Jg==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.8.1",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/css": "^1.10.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -817,12 +928,12 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.5.0.tgz",
-      "integrity": "sha512-Fr0zPqgxoNaOVdROAjNGDWCts3+wByNQ82Mxhu8Tzc25A2cPjcr1H2sa/TE3hf79c92DxdKf2FaC1ZOgR5YPdg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.6.1.tgz",
+      "integrity": "sha512-m+S3lvmSPEnPaUZzM2J/Lk8APYvMXXiJiz9UdjGa6yeW8yfR5TBPKoNPdO3XgAt13YGiNFhi/QasqsvE18iX+A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.1",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -830,7 +941,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -838,20 +949,20 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.5.0.tgz",
-      "integrity": "sha512-nbo2pdnAt21WLGjzTpsE8ZEL0xNoP7c3wBj9y70Pysmasg1SrRVCbfE8jTy+lHBQwq2yjC6lV/Usv+9lfA7S/w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.6.1.tgz",
+      "integrity": "sha512-xZ8+dygBgHQyOsMv7O1YzNGO1MKFNiE+72gN9LhjG7ld6bSix4he1af0ac7p9bpTv1cNfx/eTY604u+gv8XPqg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "@parcel/workers": "2.6.1",
         "detect-libc": "^1.0.3"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -859,19 +970,19 @@
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.5.0.tgz",
-      "integrity": "sha512-pgZqwU0RLc/wr4WcQY/W1GJmddnEANDEpz1mdppUOqBz1EfTQ7zh5NgUA3hV1i05Hbecp3mHSvXJPV0mhNOl5Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.6.1.tgz",
+      "integrity": "sha512-oyEs/8JzMJnAmJYZsWeEpC3jgyDwxA9KAnntG/41n6WDX6KDdDhY5p8B+jEvt/WQu5MQXcvIoWnMWv0W6brq+Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "svgo": "^2.4.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -879,21 +990,21 @@
       }
     },
     "node_modules/@parcel/optimizer-terser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.5.0.tgz",
-      "integrity": "sha512-PZ3UHBGfjE49/Jloopsd38Hxg4qzsrdepWP53mCuVP7Aw605Y4QtYuB1ho3VV0oXfKQVq+uI7lVIBsuW4K6vqA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.1.tgz",
+      "integrity": "sha512-h/bRdIU7Rh5MEhdX9cIGgqnu4+BpVBjRwDMqRvNirkAY6fZTLXgVb6ZxJq2jx8G4+j3sGzUmP1WaIPHeC0YJcg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -901,17 +1012,17 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
-      "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.1.tgz",
+      "integrity": "sha512-lC+e0l+rB2QYBtXetAdDSqcidni0V1eYEAYXv4+sLnAMwyCeH3x4Ctivj/w0ILzuAFnS5ow9V91boM6DQegqHQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/fs": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "@parcel/workers": "2.6.1",
         "semver": "^5.7.1"
       },
       "engines": {
@@ -922,23 +1033,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.1"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.5.0.tgz",
-      "integrity": "sha512-c0mGBFdVSPhAxaX3+zN8KEIqOOUhkIPKbZex1pnGYfy03Qe2/Mb4nyt5DAGlw9gjka1UCHIN/wszLmKC8YyUeg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.6.1.tgz",
+      "integrity": "sha512-wUGzbH8u9FyybaiCbDYdWkyrObh994PzYzj0m6rwRz+g8HNDSvzHafOnms3e/IzhtchavVwq4yvhl4xyA2WYLQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -946,20 +1057,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.5.0.tgz",
-      "integrity": "sha512-ZFGUPRMWKrm8kQHdkEJ5S22C05qpSymx+o+57EfuNjCrGyj3M59WyGYYXYJ175bFYZ/jp5yy+VxMh6fZefe+Pw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.6.1.tgz",
+      "integrity": "sha512-AzlhBG00yVvAO+3jeky5z09GLxvb9YPV+VjlExQd7OpVHlCXU7m6JafxdtesUzb63gSOsu00Hms6iNN2USv2Gg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -967,22 +1078,22 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.5.0.tgz",
-      "integrity": "sha512-aJAKOTgXdxO3V9O7+2DCVOtne128WwXmUAOVThnMRo7f3zMVSAR7Mxc9pEsuTzPfj8UBXgFBRfdJUSCgsMxiSw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.6.1.tgz",
+      "integrity": "sha512-NW2fag24sGrLwBohwk/QwqC+TYvUbh1qEWzOHQ6s1nW+12eKm+kFpSUiK3WTHhMOZoyqH/DNCdsvvHTtCXFgCA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -990,16 +1101,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.5.0.tgz",
-      "integrity": "sha512-aHV0oogeiqxhxS1lsttw15EvG3DDWK3FV7+F+7hoaAy+xg89K56NTp6j43Jtw9iyU1/HnZRGBE2hF3C7N73oKw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.6.1.tgz",
+      "integrity": "sha512-v7C9Jlp1ybUs9qbYZWIdzmdXKOZ5q5e05/YxE205UQgHy7cbuTD9ZY4xiuHAsP9qA8oBY4nD5kYyWuNSU92WWA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1007,19 +1118,19 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.5.0.tgz",
-      "integrity": "sha512-XSMFn30K/kpjcPpQqt88GmPJsNUSVL3RNeigXkIAcLpfO6Tb2eV4iOt4yVCagaDrRJ19alXut0TxjMm5bm41/g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.6.1.tgz",
+      "integrity": "sha512-ziAVCkDI7HjdXbQy3NfinRbw/nsZ8COn2oPFfukx1H3DmNhGeur3TYYLhiN0PZB45j8w9rSWoUEgDWXRqSMN4w==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1027,12 +1138,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
-      "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.1.tgz",
+      "integrity": "sha512-0QVS7mhrS9gGHtaT0KpPes2CCCAyPvvI2oZLq+NX3z7Qa73kj3Ct5QL2JuRywnefDVnkY79256oTdsq/nJrnXg==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.5.0"
+        "@parcel/types": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1043,20 +1154,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.5.0.tgz",
-      "integrity": "sha512-miJt2YbRJBmYSVeoUWUj8YL85Pwj1CmGQB0/btqhulGLH/Fvkbv6T4sJ4gl4l5xIt9mJQsZ70pOWwa8BId3rWw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.6.1.tgz",
+      "integrity": "sha512-VpVIUXReEvNko1DP+75++YQMhKLKjtyu7OziDR3AMPcRFnSbygttonK0TYg88gZ0QtHF3lNkFvn4LMECVAL5PQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1134,17 +1245,17 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.5.0.tgz",
-      "integrity": "sha512-wvxAiW42AxJ3B8jtvowJcP4/cTV8zY48SfKg61YKYu1yUO+TtyJIjHQzDW2XuT34cIGFY97Gr0i+AVu44RyUuQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.6.1.tgz",
+      "integrity": "sha512-JerLdJZdYJEchJ7lbBS79lJJHxEG2qDBmSQ5LUuX94/YNo1pQEOAQtc2Ogv98ZSjOdp8xaNYCKYKXIVd2d4gYA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0"
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1152,17 +1263,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.5.0.tgz",
-      "integrity": "sha512-39PkZpVr/+iYS11u+lA84vIsKm/yisltTVmUjlYsDnExiuV1c8OSbSdYZ3JMx+7CYPE0bWbosX2AGilIwIMWpQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.6.1.tgz",
+      "integrity": "sha512-C9kEwzluijSqdD7hXmFTRfOBNjxxrMepT5M3ZpgvtPABhZyR3epkOugD1p54ChHr3vsrfWJIjRZLi7JoI8o/VA==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "2.5.0",
-        "@parcel/plugin": "2.5.0"
+        "@parcel/node-resolver-core": "2.6.1",
+        "@parcel/plugin": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1170,17 +1281,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.5.0.tgz",
-      "integrity": "sha512-oPAo8Zf06gXCpt41nyvK7kv2HH1RrHAGgOqttyjStwAFlm5MZKs7BgtJzO58LfJN8g3sMY0cNdG17fB/4f8q6Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.6.1.tgz",
+      "integrity": "sha512-TJzONMgyU6mZ8faI8viuPzVfpPJLtesioCqDpV9/8f27JXBCL/3mRWVzoD0CJ5u94xmF0R1ErySJX5odDD++lQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0"
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1188,18 +1299,18 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.5.0.tgz",
-      "integrity": "sha512-gPC2PbNAiooULP71wF5twe4raekuXsR1Hw/ahITDoqsZdXHzG3CkoCjYL3CkmBGiKQgMMocCyN1E2oBzAH8Kyw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.6.1.tgz",
+      "integrity": "sha512-nZkSD2QR677GYS+wIS2vuqCVqIMc91+8KidkwPqrzodGVzAS1QF4SD5Fy4sB2sqGJU9yRpxIB6q8figM0uZ1SQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1207,18 +1318,19 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.5.0.tgz",
-      "integrity": "sha512-+8RuDKFdFYIQTrXG4MRhG9XqkkYEHn0zxKyOJ/IkDDfSEhY0na+EyhrneFUwIvDX63gLPkxceXAg0gwBqXPK/Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.6.1.tgz",
+      "integrity": "sha512-+ZrWKChGqsJ3xtUTd/fIeEMruSLvIMpmgujAjo6cFCzG3cOcpRcLa7mpWDydicUaWsiIx7lL5LIWu5bCS9G+DQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1226,18 +1338,18 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.5.0.tgz",
-      "integrity": "sha512-STuDlU0fPXeWpAmbayY7o04F0eHy6FTOFeT5KQ0PTxtdEa3Ey8QInP/NVE52Yv0aVQtesWukGrNEFCERlkbFRw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.6.1.tgz",
+      "integrity": "sha512-v9VbhZEEtxG3gdp4BF4JX5ji9O87RS+4HxxY2w1LHKz+t3t1ODWG5WVfIQmKD/wBwFYwQWaI6qAVXuIY26SfjQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1257,15 +1369,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.5.0.tgz",
-      "integrity": "sha512-EFb866C9jCoBHIcebWF7goAcYj1wkObx0GDxshlazFtvym1RM27xSWWjRYyqb5+HNOxB3voaNvQOVjcD+DXjCA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.6.1.tgz",
+      "integrity": "sha512-VEB62Okq7epZmmGMBro3B7LoCfLKY3HqVGWXbY3kJ+R36+2UImMyG7eGVPGf3FCJY9Jt3McGfCUKdDR4en2rFg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -1273,7 +1385,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1281,22 +1393,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.5.0.tgz",
-      "integrity": "sha512-p8FOvKWWSbS6H8PbD9a0KZqyaKNpSD2BUTzSRYnNj3TBUv7/ZXaP6Om295XTQ/MPht1o7XTQzvfpF/7yEhr02Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.6.1.tgz",
+      "integrity": "sha512-trVn7+Mx9/XNr9+eXumMuDbNRfkCmrplGQ6nlf6ZeuSs7ayNFDVuudsnC7SN1Yn+YpyWjgOD17RmlS581ZKTAw==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.8.1",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/css": "^1.10.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1304,14 +1416,14 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.5.0.tgz",
-      "integrity": "sha512-iEjNyAF0wQmY3DMw7FS+UzoOMng76UsSngh+WWA1E5lv5XyqrP8Mk2QLTJp1nWetUhSLhZr58LGmPYBTB4l9ZQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.6.1.tgz",
+      "integrity": "sha512-GpHXG8v1U0heCbNVQ8gmnJJqAkceKROvj7BreR7UokXP+Frr+ydKKumbVLK7kjwwlagy85VMnIMaFG8/zZ4lqA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1320,7 +1432,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1328,35 +1440,35 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.5.0.tgz",
-      "integrity": "sha512-vVEXTHZl8m/9yopgK0dWHLOQX2zOnghq6pZnWdWVG6fsvXZln7kP1YN5iwWDoADQYkiKzP+Ymn6UwP9pZpHFzA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.6.1.tgz",
+      "integrity": "sha512-s+ht/DD2pzCx0yq4L6rNHu8oxTQ6Xx8PKcxZxlEsaW2xyDWJ0nvhLE0p296Xa+A4Vw31DENIe1Wq1PQ2C6UrTA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/workers": "2.6.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.1"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.5.0.tgz",
-      "integrity": "sha512-Cp8Ic+Au3OcskCRZszmo47z3bqcZ7rfPv2xZYXpXY2TzEc3IV0bKje57bZektoY8LW9LkYM9iBO/WhkVoT6LIg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.6.1.tgz",
+      "integrity": "sha512-jtf154aL7OCbsgi0A4Bk/2oYfdNIFRILho7UXIQ0qszkCj0IDO67bzUF1Q4JuAFS9vyqulyId6HYFqCkmOlv3A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
-        "@swc/helpers": "^0.3.6",
+        "@parcel/utils": "2.6.1",
+        "@parcel/workers": "2.6.1",
+        "@swc/helpers": "^0.4.2",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
@@ -1365,28 +1477,28 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.1"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.5.0.tgz",
-      "integrity": "sha512-661sByA7TkR6Lmxt+hqV4h2SAt+7lgc58DzmUYArpEl1fQnMuQuaB0kQeHzi6fDD2+2G6o7EC+DuwBZKa479TA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.6.1.tgz",
+      "integrity": "sha512-GPI+mUiLm/B8eR7zXWIV252TQarN6Qv3S0wnJhs30gA8EI8/MkFkEgJFoKAKP7saV/r2gnONEZlovQvTuF0oqw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.1",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1394,15 +1506,15 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.5.0.tgz",
-      "integrity": "sha512-IPNlWElekdQHMTBqhdwJNBCQomuYyo7xgNBdnTrt9VJ+R5ihy6n7ZJSWIAJXAH9VZxETTtunfrzRtgkmtjTeZQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.6.1.tgz",
+      "integrity": "sha512-NeZDXa9PkvHgwNWWtxaJWgGu7oq+jReCd1L/uXQRcNys2feUApdlQuKIjea1uL1UK6ydsS2kzmv/HqGWK3nGxA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -1410,7 +1522,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1418,13 +1530,13 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.5.0.tgz",
-      "integrity": "sha512-AZxg1XD8OXOS4bEGEmBBR+X9T9qoFdVsbVUg498zzejYSka1ZQHF7TgLI/+pUnE+ZVYNIp7/G0xXqsRVKMKmdQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.6.1.tgz",
+      "integrity": "sha512-XzfQf193m0RrlTzKDpqWWnS3ONn9xD9C8pKGvWapmrfFIMSwiOTY3EHUD8P3kCeon2CyddfshU1Y6yPkVdreww==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1433,7 +1545,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1441,16 +1553,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.5.0.tgz",
-      "integrity": "sha512-I3zjE1u9+Wj90Qqs1V2FTm6iC6SAyOVUthwVZkZey+qbQG/ok682Ez2XjLu7MyQCo9BJNwF/nfOa1hHr3MaJEQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.6.1.tgz",
+      "integrity": "sha512-gkuUksA8TDjaSlU9I2MFH4R3WfHXBOHLZlZ+juPK2rlLhhe8A/mvwOuWreNyjQTnKt6QXkdIkvgc9gTlsSHnXQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1458,18 +1570,18 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.5.0.tgz",
-      "integrity": "sha512-VPqVBxhTN4OQwcjsdyxrv+smjAm4s6dbSWAplgPwdOITMv+a0tjhhJU37WnRC+xxTrbEqRcOt96JvGOkPb8i7g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.6.1.tgz",
+      "integrity": "sha512-EZg2OKsurEmvcCkbroL2v6sBk7X790BK7nlrCHug9EX8aatiwvabxBPlx9aRUwUEjqRBosmS+fmU1exKpqBZxA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1477,14 +1589,14 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.5.0.tgz",
-      "integrity": "sha512-zCGJcrCpICFe0Q/dgjQZfW7sYFkbJEC7NGT4zEJnMo8Cm/kq8Qh6+2ApX6c+vv5Q0WZn5Ic+N0OvxIMkvgdC/w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.6.1.tgz",
+      "integrity": "sha512-k9ccxU4eLMrmKDTdXbabq6C/TsF+bOSrWQYOC8QK+VPSF91S47vhVqLTiFeguB8bJGeLgd4uGS+YgdOLGjAJcw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1493,7 +1605,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1501,31 +1613,31 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
-      "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.1.tgz",
+      "integrity": "sha512-IXt0MiBmg95SKOAyvRNjcNlJvWUMtvCw6ea7+h1mWStm4gcJBoaznbgLJsG2C17AJ2F8CNR/5jZKlM9SDzTayg==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
+        "@parcel/cache": "2.6.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/fs": "2.6.1",
+        "@parcel/package-manager": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/workers": "2.6.1",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
-      "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.1.tgz",
+      "integrity": "sha512-jMoNNBVGGs1IeNZnGGJv3R2otmf39X/0OerpuI27Ut4iCt79y6TVMFdoB7eG2aEYFdL6cD7xNfieQvX+6nrjoQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/markdown-ansi": "2.5.0",
+        "@parcel/codeframe": "2.6.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/markdown-ansi": "2.6.1",
         "@parcel/source-map": "^2.0.0",
         "chalk": "^4.1.0"
       },
@@ -1626,15 +1738,15 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
-      "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.1.tgz",
+      "integrity": "sha512-KIXu5HAmnEDIDwwJDnLzlr0avsewux3rWHe/nN43ERgj2j5j1nVqIulE7tX+XKAM3AHTFKWHJi5RLX4Htl2wwg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       },
@@ -1646,13 +1758,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.5.0"
+        "@parcel/core": "^2.6.1"
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.13.tgz",
-      "integrity": "sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz",
+      "integrity": "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2929,18 +3041,6 @@
         "entities": "^3.0.1"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3112,7 +3212,7 @@
     "node_modules/is-json": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=",
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
       "dev": true
     },
     "node_modules/is-map": {
@@ -3415,17 +3515,42 @@
       "dev": true
     },
     "node_modules/lmdb": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-      "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "msgpackr": "^1.5.4",
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
         "ordered-binary": "^1.2.4",
         "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2"
+      }
+    },
+    "node_modules/lmdb/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true
+    },
+    "node_modules/lmdb/node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "dev": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/load-json-file": {
@@ -3457,12 +3582,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -3817,12 +3936,6 @@
         "win32"
       ]
     },
-    "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
@@ -3923,9 +4036,9 @@
       }
     },
     "node_modules/nth-check": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
-      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
@@ -4039,21 +4152,21 @@
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
     },
     "node_modules/parcel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.5.0.tgz",
-      "integrity": "sha512-er0mj/BaMjWyzQ/jedLUi/LNAuQcFT8lCvoNqANF+jTaX9rohaBwxIvKVJVAZgyCnmyfbbldp496wPMW0R0+CA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.6.1.tgz",
+      "integrity": "sha512-dqPG1u7NV/nlnoU6O9zO6sIFbna7b8IfmoNgMM0un2+EtOhNlz4bRp6U4AHosTulMUTKFmHpdXXG4dF9X0WQtw==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.5.0",
-        "@parcel/core": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/reporter-cli": "2.5.0",
-        "@parcel/reporter-dev-server": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/config-default": "2.6.1",
+        "@parcel/core": "2.6.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/events": "2.6.1",
+        "@parcel/fs": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/package-manager": "2.6.1",
+        "@parcel/reporter-cli": "2.6.1",
+        "@parcel/reporter-dev-server": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0",
@@ -4304,15 +4417,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4321,6 +4425,12 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "node_modules/react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+      "dev": true
     },
     "node_modules/react-refresh": {
       "version": "0.9.0",
@@ -4456,12 +4566,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "node_modules/semver": {
@@ -4786,14 +4890,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
+      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -4808,18 +4912,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -4838,7 +4930,7 @@
     "node_modules/timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
       "dev": true
     },
     "node_modules/tiny-inflate": {
@@ -4856,15 +4948,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/tslib": {
@@ -4977,23 +5060,6 @@
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
-    },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -5235,11 +5301,38 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
+      "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
       "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
       "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
@@ -5272,6 +5365,48 @@
         "@lezer/common": "^0.15.0"
       }
     },
+    "@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "dev": true,
+      "optional": true
+    },
     "@mischnic/json-sourcemap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
@@ -5284,34 +5419,34 @@
       }
     },
     "@parcel/bundler-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.5.0.tgz",
-      "integrity": "sha512-7CJzE17SirCXjcRgBcnqWO/5EOA1raq/3OIKtT4cxbjpDQGHZpjpEEZiMNRpEpdNMxDSlsG8mAkXTYGL2VVWRw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.6.1.tgz",
+      "integrity": "sha512-hCaLnvanoQcWp+09WGdo3q1/qrqLuwgoWf3wU5IrQgx77JqnASBTn0/qkEes5vNH0VbHDWmwtPSoECPLWxNS/A==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.1.tgz",
+      "integrity": "sha512-FjG9DDLUCxlnS32cF7riga8gwMKbwxKnVIUsKZU5K9I+Sd5HtKRqn8H3e7dksCiVCPqZR3jItnr7FH9bEniWJA==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "lmdb": "2.2.4"
+        "@parcel/fs": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "lmdb": "2.5.2"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
-      "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.1.tgz",
+      "integrity": "sha512-6GR9w9cccxCMbDqXNfEGwFjju+Ks3mMDaiLuLXIITkuEYgxdbXrpNlcpD0tJiSJn3cyo8gieUYFF4wlJyuS/gQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
@@ -5369,72 +5504,72 @@
       }
     },
     "@parcel/compressor-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.5.0.tgz",
-      "integrity": "sha512-I5Zs+2f1ue4sTPdfT8BNsLfTZl48sMWLk2Io3elUJjH/SS9kO7ut5ChkuJtt77ZS35m0OF+ZCt3ICTJdnDG8eA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.6.1.tgz",
+      "integrity": "sha512-UbA1xndQHZVWXdkVN/3PH0libsB6M1urEvTOrtxXiZS4bVGqj/UwoZ47OZA92ls0q35Qa0tWjQ6zBmlrgRWCsg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.1"
       }
     },
     "@parcel/config-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.5.0.tgz",
-      "integrity": "sha512-r30V61958SONvP9I8KV8s44ZOFq0H219VyFjPysraSabHjZ+KMaCTQOuqaDtUMa272sHUQkBcZxKYj5jYPJlZg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.6.1.tgz",
+      "integrity": "sha512-upW4K2fdljpcHhmniEGVdBjqonFUqfONMWnxrS3WEikcuCwr2/IVLD61w0MPLEeu8Xbr2anHJwh2/kl7DiWDZQ==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.5.0",
-        "@parcel/compressor-raw": "2.5.0",
-        "@parcel/namer-default": "2.5.0",
-        "@parcel/optimizer-css": "2.5.0",
-        "@parcel/optimizer-htmlnano": "2.5.0",
-        "@parcel/optimizer-image": "2.5.0",
-        "@parcel/optimizer-svgo": "2.5.0",
-        "@parcel/optimizer-terser": "2.5.0",
-        "@parcel/packager-css": "2.5.0",
-        "@parcel/packager-html": "2.5.0",
-        "@parcel/packager-js": "2.5.0",
-        "@parcel/packager-raw": "2.5.0",
-        "@parcel/packager-svg": "2.5.0",
-        "@parcel/reporter-dev-server": "2.5.0",
-        "@parcel/resolver-default": "2.5.0",
-        "@parcel/runtime-browser-hmr": "2.5.0",
-        "@parcel/runtime-js": "2.5.0",
-        "@parcel/runtime-react-refresh": "2.5.0",
-        "@parcel/runtime-service-worker": "2.5.0",
-        "@parcel/transformer-babel": "2.5.0",
-        "@parcel/transformer-css": "2.5.0",
-        "@parcel/transformer-html": "2.5.0",
-        "@parcel/transformer-image": "2.5.0",
-        "@parcel/transformer-js": "2.5.0",
-        "@parcel/transformer-json": "2.5.0",
-        "@parcel/transformer-postcss": "2.5.0",
-        "@parcel/transformer-posthtml": "2.5.0",
-        "@parcel/transformer-raw": "2.5.0",
-        "@parcel/transformer-react-refresh-wrap": "2.5.0",
-        "@parcel/transformer-svg": "2.5.0"
+        "@parcel/bundler-default": "2.6.1",
+        "@parcel/compressor-raw": "2.6.1",
+        "@parcel/namer-default": "2.6.1",
+        "@parcel/optimizer-css": "2.6.1",
+        "@parcel/optimizer-htmlnano": "2.6.1",
+        "@parcel/optimizer-image": "2.6.1",
+        "@parcel/optimizer-svgo": "2.6.1",
+        "@parcel/optimizer-terser": "2.6.1",
+        "@parcel/packager-css": "2.6.1",
+        "@parcel/packager-html": "2.6.1",
+        "@parcel/packager-js": "2.6.1",
+        "@parcel/packager-raw": "2.6.1",
+        "@parcel/packager-svg": "2.6.1",
+        "@parcel/reporter-dev-server": "2.6.1",
+        "@parcel/resolver-default": "2.6.1",
+        "@parcel/runtime-browser-hmr": "2.6.1",
+        "@parcel/runtime-js": "2.6.1",
+        "@parcel/runtime-react-refresh": "2.6.1",
+        "@parcel/runtime-service-worker": "2.6.1",
+        "@parcel/transformer-babel": "2.6.1",
+        "@parcel/transformer-css": "2.6.1",
+        "@parcel/transformer-html": "2.6.1",
+        "@parcel/transformer-image": "2.6.1",
+        "@parcel/transformer-js": "2.6.1",
+        "@parcel/transformer-json": "2.6.1",
+        "@parcel/transformer-postcss": "2.6.1",
+        "@parcel/transformer-posthtml": "2.6.1",
+        "@parcel/transformer-raw": "2.6.1",
+        "@parcel/transformer-react-refresh-wrap": "2.6.1",
+        "@parcel/transformer-svg": "2.6.1"
       }
     },
     "@parcel/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-dygDmPsfAYJKTnUftcbEzjCik7AAaPbFvJW8ETYz8diyjkAG9y6hvCAZIrJE5pNOjFzg32en4v4UWv8Sqlzl9g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-FcinQQEtqqb0cSj4JPD8vx/qMkz1rWdbxtdEPG0W1cA2I5qcVPMgkHsVFrDnWQlQIquwu98um8zg1MrN1KrRew==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/graph": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/cache": "2.6.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/events": "2.6.1",
+        "@parcel/fs": "2.6.1",
+        "@parcel/graph": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/package-manager": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "@parcel/workers": "2.6.1",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -5448,82 +5583,82 @@
       }
     },
     "@parcel/css": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.8.3.tgz",
-      "integrity": "sha512-6qUN4iicr8f9Q6UUZttwwHMzrb65BRX46PHWq0icA4KEmvmfR9cSYlp/hJH8F4stg3Wncx12Bnw+EuPf5OAEPQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.10.1.tgz",
+      "integrity": "sha512-qnoQM4qH6ytYE3RK8PzMoI8dGPmJv/fNFkeC8Ku0A08GbG/ssir2TCQCarcKFVNgvtfDZ0AX3+vjSkYEAfzhJA==",
       "dev": true,
       "requires": {
-        "@parcel/css-darwin-arm64": "1.8.3",
-        "@parcel/css-darwin-x64": "1.8.3",
-        "@parcel/css-linux-arm-gnueabihf": "1.8.3",
-        "@parcel/css-linux-arm64-gnu": "1.8.3",
-        "@parcel/css-linux-arm64-musl": "1.8.3",
-        "@parcel/css-linux-x64-gnu": "1.8.3",
-        "@parcel/css-linux-x64-musl": "1.8.3",
-        "@parcel/css-win32-x64-msvc": "1.8.3",
+        "@parcel/css-darwin-arm64": "1.10.1",
+        "@parcel/css-darwin-x64": "1.10.1",
+        "@parcel/css-linux-arm-gnueabihf": "1.10.1",
+        "@parcel/css-linux-arm64-gnu": "1.10.1",
+        "@parcel/css-linux-arm64-musl": "1.10.1",
+        "@parcel/css-linux-x64-gnu": "1.10.1",
+        "@parcel/css-linux-x64-musl": "1.10.1",
+        "@parcel/css-win32-x64-msvc": "1.10.1",
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/css-darwin-arm64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.8.3.tgz",
-      "integrity": "sha512-qh/Ig6GfVjGoiGSWjIYDo6Ghwmyy/9BXvYS1l3R+Bp50F300cq84Czfl6wxaL+aFmghdHzhjJuGfWmZlcYliPA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.10.1.tgz",
+      "integrity": "sha512-0ukr4/hSrM24ef8bcZ5b/o8iJrPVAxXOKCPGpmKFd+R/31SYjvFfMJzS2XAYUy0W0FunMW2fte3iTPNMDigyww==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-darwin-x64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.8.3.tgz",
-      "integrity": "sha512-gTUIoRgwyYr4UuH7sSn3gOuMlIshJBOJLmjL+E/mR5lqdYabguiKiRORvkrnb/gHBmOUF9re0RcTaFmJ2VOAlg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.10.1.tgz",
+      "integrity": "sha512-PFMPptY+OswU68XgBO2RlL6JckeWz/a36r7ys6LMPrNonIOWGce155lwnylBK1Pnx1DRQAN8jWaolo+OkD9RRQ==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm-gnueabihf": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.8.3.tgz",
-      "integrity": "sha512-4P1r0BvL9dPz70py2xLg/jEvWJmKNyokPgafyrDP+GbpPTfH5NYJJkVRGo/TkKsp3Rv8SJhV9fdlpFKC6BI92A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.10.1.tgz",
+      "integrity": "sha512-QICiX10CDudilEV+DUBKbbJb7ckSuj2hyI3NyzphRqkxBE7t4Hb04x6RPKITEJwHgvqUQ3OUPWyvtalVAi36Ww==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm64-gnu": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.8.3.tgz",
-      "integrity": "sha512-1fUy94eaqdzum+C7bsYVF2AgxjLGR/qppArn/4HTQyydHR5QeV+Uoyqo5vdnO5Vclj8eQwlgR9OyAOlmzXxFDA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.10.1.tgz",
+      "integrity": "sha512-dHaQiBXlrDPdqE8O1qnlYqp1N9la1jgcYgIUCtm4NkNltzLVbbSFXyeG7OXeT6njP6ltMb4mmEFL18I2Wr3l3A==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-arm64-musl": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.8.3.tgz",
-      "integrity": "sha512-ct1QRK5gAP8sO22NZ7RULZQB7dbHpou+WMa4z0LJb+Fho13a1JNw931vNHbeI5cRr1fCTDq76pz/+Valgetzcw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.10.1.tgz",
+      "integrity": "sha512-inBbDCGhJaZcNCb588wQz5tYpGbnz8W/g9aFOH6X3nSBNToknOHplBHjOMLOB7vBxAykNjbywaNtE5H9qoY0/A==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-x64-gnu": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.8.3.tgz",
-      "integrity": "sha512-pg/mahoogzjbaZcW76rrTZ64tEu8Wok4Gm0sW/dXHJEJD2QVJ6GxLP4UVNBuhaV0GrNFHggp9pcdhTtLGkKl/g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.10.1.tgz",
+      "integrity": "sha512-gBaHgMXom1lCGu/ummD1wqknxF9ZKFBUlxQ/0DtCdOtZlRBEKeWtoskK9tgH4YMnwTpMIagCwWB4UbP/9Yzz6A==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-linux-x64-musl": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.8.3.tgz",
-      "integrity": "sha512-4Iwawy28HQ2yAgbuyR60bgO+8oE+OiWpE02eNjbgqnDpTsfmXFMt4l5OYgZwJJ7DlaZqm+/yO8RPMd+EzwtNzg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.10.1.tgz",
+      "integrity": "sha512-arjLARo/3l0uwPf5qYxCkrS0FTE8n6JH/S1/7DitvhG22fsZdJTGPwe4MYLTIn4s3QXLOVVRrkPDZlUPM1yjFA==",
       "dev": true,
       "optional": true
     },
     "@parcel/css-win32-x64-msvc": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.8.3.tgz",
-      "integrity": "sha512-vnHUdzIVjqONa5ALFzMJ3ZHt6NiaYTHW/lqzP+AR4l+bq+UTXD2Q75/RgirY5NYwdfy1VPy/jI82jAtLOCymkw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.10.1.tgz",
+      "integrity": "sha512-f/jkhL2uOZCHJg3/IGcuieZ4TTwkxExLd7SWVuiqJZI2nwOy/gLHTZJz3yzu/D1aLOe0M9/glgzUKRtK0DrUNA==",
       "dev": true,
       "optional": true
     },
     "@parcel/diagnostic": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
-      "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.1.tgz",
+      "integrity": "sha512-7lbmRCHEeS8uzO+BzfTtiJMfeOKf5HOTaVE+kzTkfqHT/H3ChD1rNQQdxTjE+TvX2k7lLdEE6Qstj7OmrE/xQg==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -5531,47 +5666,47 @@
       }
     },
     "@parcel/events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
-      "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.1.tgz",
+      "integrity": "sha512-x0PkTFm2wm1hIfwD/p0jNuCUM0t2NwzUxdZrTHm9ncqrYbO2tpG0N5jkTC9V9fu7j639vGVA7uOHYFgExTKUbQ==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
-      "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.1.tgz",
+      "integrity": "sha512-+kI2IPdZ5WH94+9LMCO/INnJUcbPcfVim97ORMjfe3mOYEPEQYqzM5g8SLjqiW/H5OIVapdIYoHWBEBpo3itdA==",
       "dev": true,
       "requires": {
-        "@parcel/fs-search": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/fs-search": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.5.0"
+        "@parcel/workers": "2.6.1"
       }
     },
     "@parcel/fs-search": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
-      "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.1.tgz",
+      "integrity": "sha512-vfbknvzUjy1PQuCfjfbCQUIQXCUb+n+sd5CZHOODvE4PewvspW/YmKJpYluDr0S4mOa1GX7cHJCL675DALW5yQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/graph": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.5.0.tgz",
-      "integrity": "sha512-qa2VtG08dJyTaWrxYAkMIlkoDRSPoiqLDNxxHKplkcxAjXBUw0/AkWaz82VO5r1G6jfOj+nM30ajH9uygZYwbw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.1.tgz",
+      "integrity": "sha512-tzv9P3hyS9SZiwmE6KB1ZFhXV3/vjFNZV7+XGbf1opI3oTwawBb+XaH4k7InPyVYZTo1QrlauhoP+EQZFyzPEQ==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/hash": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
-      "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.1.tgz",
+      "integrity": "sha512-5gve/OKOXzYADfCJ+atpR6L13n4clexazkNRcsm6LZtE2Gm84Nx81gdb8z08EJrZALC62f9J2FOmQxm6ZHrTSQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -5579,19 +5714,19 @@
       }
     },
     "@parcel/logger": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
-      "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.1.tgz",
+      "integrity": "sha512-AnKAVS/QRi1ee+Q1MxL+oUZT7dBZ36VUtevmXMSaaoN3W1KwYjM4Brq3zdiTZRfa7Akpdu6Ca1QVK5hGpvXKSg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0"
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/events": "2.6.1"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
-      "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.1.tgz",
+      "integrity": "sha512-p4dDINi+UeEUQfkA70R9gNJIuSnMuljSUfHf7erTU8vSqRD1tQpnmH7GfzzQLHYwHk8UYICGU8C6z7EtPH92Ng==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
@@ -5649,49 +5784,50 @@
       }
     },
     "@parcel/namer-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
-      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.1.tgz",
+      "integrity": "sha512-J7KajS6s0GvpZ0YIN8t/Z4Go/E7tS136bKyvSdWhVOUosmt2pW1L20lq9KfPVYDvWQNu12jqJbAHQFsqOLyllw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.5.0.tgz",
-      "integrity": "sha512-XQvpguiIwQcu75cscLDFOVhjsjuPzXbuMaaZ7XxxUEl0PscIgu/GfKYxTfTruN3cRl+CaQH6qBAMfjLaFng6lQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.6.1.tgz",
+      "integrity": "sha512-LaLiJkgr5Cq9ue5wxsFR97S3R+IOGkmvivNsdc4Y9Gdj9WO1nMTaNMBlw+AIjtbzdbw0MUvKQik2tR4AmfBcLw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "nullthrows": "^1.1.1"
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
       }
     },
     "@parcel/optimizer-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.5.0.tgz",
-      "integrity": "sha512-J00bLF+4SsnKc+YbYrNuBr44/zz3cg++CoXteXhH27PxP1rScGQx36Rui8WORgil5mlX2VYN79DuqJC7V3Ynbg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.6.1.tgz",
+      "integrity": "sha512-VNdATqH068XCbzaOBbgdZOBJAMomkXOqcmxXOmQkHqTKqBO11xXLIESP+PQwTXoxy7If+2ufxOPCHTI20691Jg==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.8.1",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/css": "^1.10.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.5.0.tgz",
-      "integrity": "sha512-Fr0zPqgxoNaOVdROAjNGDWCts3+wByNQ82Mxhu8Tzc25A2cPjcr1H2sa/TE3hf79c92DxdKf2FaC1ZOgR5YPdg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.6.1.tgz",
+      "integrity": "sha512-m+S3lvmSPEnPaUZzM2J/Lk8APYvMXXiJiz9UdjGa6yeW8yfR5TBPKoNPdO3XgAt13YGiNFhi/QasqsvE18iX+A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.1",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -5699,138 +5835,138 @@
       }
     },
     "@parcel/optimizer-image": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.5.0.tgz",
-      "integrity": "sha512-nbo2pdnAt21WLGjzTpsE8ZEL0xNoP7c3wBj9y70Pysmasg1SrRVCbfE8jTy+lHBQwq2yjC6lV/Usv+9lfA7S/w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.6.1.tgz",
+      "integrity": "sha512-xZ8+dygBgHQyOsMv7O1YzNGO1MKFNiE+72gN9LhjG7ld6bSix4he1af0ac7p9bpTv1cNfx/eTY604u+gv8XPqg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "@parcel/workers": "2.6.1",
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/optimizer-svgo": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.5.0.tgz",
-      "integrity": "sha512-pgZqwU0RLc/wr4WcQY/W1GJmddnEANDEpz1mdppUOqBz1EfTQ7zh5NgUA3hV1i05Hbecp3mHSvXJPV0mhNOl5Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.6.1.tgz",
+      "integrity": "sha512-oyEs/8JzMJnAmJYZsWeEpC3jgyDwxA9KAnntG/41n6WDX6KDdDhY5p8B+jEvt/WQu5MQXcvIoWnMWv0W6brq+Q==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "svgo": "^2.4.0"
       }
     },
     "@parcel/optimizer-terser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.5.0.tgz",
-      "integrity": "sha512-PZ3UHBGfjE49/Jloopsd38Hxg4qzsrdepWP53mCuVP7Aw605Y4QtYuB1ho3VV0oXfKQVq+uI7lVIBsuW4K6vqA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.1.tgz",
+      "integrity": "sha512-h/bRdIU7Rh5MEhdX9cIGgqnu4+BpVBjRwDMqRvNirkAY6fZTLXgVb6ZxJq2jx8G4+j3sGzUmP1WaIPHeC0YJcg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       }
     },
     "@parcel/package-manager": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
-      "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.1.tgz",
+      "integrity": "sha512-lC+e0l+rB2QYBtXetAdDSqcidni0V1eYEAYXv4+sLnAMwyCeH3x4Ctivj/w0ILzuAFnS5ow9V91boM6DQegqHQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/fs": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "@parcel/workers": "2.6.1",
         "semver": "^5.7.1"
       }
     },
     "@parcel/packager-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.5.0.tgz",
-      "integrity": "sha512-c0mGBFdVSPhAxaX3+zN8KEIqOOUhkIPKbZex1pnGYfy03Qe2/Mb4nyt5DAGlw9gjka1UCHIN/wszLmKC8YyUeg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.6.1.tgz",
+      "integrity": "sha512-wUGzbH8u9FyybaiCbDYdWkyrObh994PzYzj0m6rwRz+g8HNDSvzHafOnms3e/IzhtchavVwq4yvhl4xyA2WYLQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.5.0.tgz",
-      "integrity": "sha512-ZFGUPRMWKrm8kQHdkEJ5S22C05qpSymx+o+57EfuNjCrGyj3M59WyGYYXYJ175bFYZ/jp5yy+VxMh6fZefe+Pw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.6.1.tgz",
+      "integrity": "sha512-AzlhBG00yVvAO+3jeky5z09GLxvb9YPV+VjlExQd7OpVHlCXU7m6JafxdtesUzb63gSOsu00Hms6iNN2USv2Gg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.5.0.tgz",
-      "integrity": "sha512-aJAKOTgXdxO3V9O7+2DCVOtne128WwXmUAOVThnMRo7f3zMVSAR7Mxc9pEsuTzPfj8UBXgFBRfdJUSCgsMxiSw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.6.1.tgz",
+      "integrity": "sha512-NW2fag24sGrLwBohwk/QwqC+TYvUbh1qEWzOHQ6s1nW+12eKm+kFpSUiK3WTHhMOZoyqH/DNCdsvvHTtCXFgCA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.5.0.tgz",
-      "integrity": "sha512-aHV0oogeiqxhxS1lsttw15EvG3DDWK3FV7+F+7hoaAy+xg89K56NTp6j43Jtw9iyU1/HnZRGBE2hF3C7N73oKw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.6.1.tgz",
+      "integrity": "sha512-v7C9Jlp1ybUs9qbYZWIdzmdXKOZ5q5e05/YxE205UQgHy7cbuTD9ZY4xiuHAsP9qA8oBY4nD5kYyWuNSU92WWA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.1"
       }
     },
     "@parcel/packager-svg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.5.0.tgz",
-      "integrity": "sha512-XSMFn30K/kpjcPpQqt88GmPJsNUSVL3RNeigXkIAcLpfO6Tb2eV4iOt4yVCagaDrRJ19alXut0TxjMm5bm41/g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.6.1.tgz",
+      "integrity": "sha512-ziAVCkDI7HjdXbQy3NfinRbw/nsZ8COn2oPFfukx1H3DmNhGeur3TYYLhiN0PZB45j8w9rSWoUEgDWXRqSMN4w==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "posthtml": "^0.16.4"
       }
     },
     "@parcel/plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
-      "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.1.tgz",
+      "integrity": "sha512-0QVS7mhrS9gGHtaT0KpPes2CCCAyPvvI2oZLq+NX3z7Qa73kj3Ct5QL2JuRywnefDVnkY79256oTdsq/nJrnXg==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.5.0"
+        "@parcel/types": "2.6.1"
       }
     },
     "@parcel/reporter-cli": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.5.0.tgz",
-      "integrity": "sha512-miJt2YbRJBmYSVeoUWUj8YL85Pwj1CmGQB0/btqhulGLH/Fvkbv6T4sJ4gl4l5xIt9mJQsZ70pOWwa8BId3rWw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.6.1.tgz",
+      "integrity": "sha512-VpVIUXReEvNko1DP+75++YQMhKLKjtyu7OziDR3AMPcRFnSbygttonK0TYg88gZ0QtHF3lNkFvn4LMECVAL5PQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       },
@@ -5887,65 +6023,66 @@
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.5.0.tgz",
-      "integrity": "sha512-wvxAiW42AxJ3B8jtvowJcP4/cTV8zY48SfKg61YKYu1yUO+TtyJIjHQzDW2XuT34cIGFY97Gr0i+AVu44RyUuQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.6.1.tgz",
+      "integrity": "sha512-JerLdJZdYJEchJ7lbBS79lJJHxEG2qDBmSQ5LUuX94/YNo1pQEOAQtc2Ogv98ZSjOdp8xaNYCKYKXIVd2d4gYA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0"
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1"
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.5.0.tgz",
-      "integrity": "sha512-39PkZpVr/+iYS11u+lA84vIsKm/yisltTVmUjlYsDnExiuV1c8OSbSdYZ3JMx+7CYPE0bWbosX2AGilIwIMWpQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.6.1.tgz",
+      "integrity": "sha512-C9kEwzluijSqdD7hXmFTRfOBNjxxrMepT5M3ZpgvtPABhZyR3epkOugD1p54ChHr3vsrfWJIjRZLi7JoI8o/VA==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "2.5.0",
-        "@parcel/plugin": "2.5.0"
+        "@parcel/node-resolver-core": "2.6.1",
+        "@parcel/plugin": "2.6.1"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.5.0.tgz",
-      "integrity": "sha512-oPAo8Zf06gXCpt41nyvK7kv2HH1RrHAGgOqttyjStwAFlm5MZKs7BgtJzO58LfJN8g3sMY0cNdG17fB/4f8q6Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.6.1.tgz",
+      "integrity": "sha512-TJzONMgyU6mZ8faI8viuPzVfpPJLtesioCqDpV9/8f27JXBCL/3mRWVzoD0CJ5u94xmF0R1ErySJX5odDD++lQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0"
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.5.0.tgz",
-      "integrity": "sha512-gPC2PbNAiooULP71wF5twe4raekuXsR1Hw/ahITDoqsZdXHzG3CkoCjYL3CkmBGiKQgMMocCyN1E2oBzAH8Kyw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.6.1.tgz",
+      "integrity": "sha512-nZkSD2QR677GYS+wIS2vuqCVqIMc91+8KidkwPqrzodGVzAS1QF4SD5Fy4sB2sqGJU9yRpxIB6q8figM0uZ1SQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.5.0.tgz",
-      "integrity": "sha512-+8RuDKFdFYIQTrXG4MRhG9XqkkYEHn0zxKyOJ/IkDDfSEhY0na+EyhrneFUwIvDX63gLPkxceXAg0gwBqXPK/Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.6.1.tgz",
+      "integrity": "sha512-+ZrWKChGqsJ3xtUTd/fIeEMruSLvIMpmgujAjo6cFCzG3cOcpRcLa7mpWDydicUaWsiIx7lL5LIWu5bCS9G+DQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
+        "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/runtime-service-worker": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.5.0.tgz",
-      "integrity": "sha512-STuDlU0fPXeWpAmbayY7o04F0eHy6FTOFeT5KQ0PTxtdEa3Ey8QInP/NVE52Yv0aVQtesWukGrNEFCERlkbFRw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.6.1.tgz",
+      "integrity": "sha512-v9VbhZEEtxG3gdp4BF4JX5ji9O87RS+4HxxY2w1LHKz+t3t1ODWG5WVfIQmKD/wBwFYwQWaI6qAVXuIY26SfjQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1"
       }
     },
@@ -5959,15 +6096,15 @@
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.5.0.tgz",
-      "integrity": "sha512-EFb866C9jCoBHIcebWF7goAcYj1wkObx0GDxshlazFtvym1RM27xSWWjRYyqb5+HNOxB3voaNvQOVjcD+DXjCA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.6.1.tgz",
+      "integrity": "sha512-VEB62Okq7epZmmGMBro3B7LoCfLKY3HqVGWXbY3kJ+R36+2UImMyG7eGVPGf3FCJY9Jt3McGfCUKdDR4en2rFg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -5975,29 +6112,29 @@
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.5.0.tgz",
-      "integrity": "sha512-p8FOvKWWSbS6H8PbD9a0KZqyaKNpSD2BUTzSRYnNj3TBUv7/ZXaP6Om295XTQ/MPht1o7XTQzvfpF/7yEhr02Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.6.1.tgz",
+      "integrity": "sha512-trVn7+Mx9/XNr9+eXumMuDbNRfkCmrplGQ6nlf6ZeuSs7ayNFDVuudsnC7SN1Yn+YpyWjgOD17RmlS581ZKTAw==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.8.1",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/css": "^1.10.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/utils": "2.6.1",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.5.0.tgz",
-      "integrity": "sha512-iEjNyAF0wQmY3DMw7FS+UzoOMng76UsSngh+WWA1E5lv5XyqrP8Mk2QLTJp1nWetUhSLhZr58LGmPYBTB4l9ZQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.6.1.tgz",
+      "integrity": "sha512-GpHXG8v1U0heCbNVQ8gmnJJqAkceKROvj7BreR7UokXP+Frr+ydKKumbVLK7kjwwlagy85VMnIMaFG8/zZ4lqA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -6006,28 +6143,28 @@
       }
     },
     "@parcel/transformer-image": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.5.0.tgz",
-      "integrity": "sha512-vVEXTHZl8m/9yopgK0dWHLOQX2zOnghq6pZnWdWVG6fsvXZln7kP1YN5iwWDoADQYkiKzP+Ymn6UwP9pZpHFzA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.6.1.tgz",
+      "integrity": "sha512-s+ht/DD2pzCx0yq4L6rNHu8oxTQ6Xx8PKcxZxlEsaW2xyDWJ0nvhLE0p296Xa+A4Vw31DENIe1Wq1PQ2C6UrTA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/workers": "2.6.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.5.0.tgz",
-      "integrity": "sha512-Cp8Ic+Au3OcskCRZszmo47z3bqcZ7rfPv2xZYXpXY2TzEc3IV0bKje57bZektoY8LW9LkYM9iBO/WhkVoT6LIg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.6.1.tgz",
+      "integrity": "sha512-jtf154aL7OCbsgi0A4Bk/2oYfdNIFRILho7UXIQ0qszkCj0IDO67bzUF1Q4JuAFS9vyqulyId6HYFqCkmOlv3A==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
-        "@swc/helpers": "^0.3.6",
+        "@parcel/utils": "2.6.1",
+        "@parcel/workers": "2.6.1",
+        "@swc/helpers": "^0.4.2",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
@@ -6036,25 +6173,25 @@
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.5.0.tgz",
-      "integrity": "sha512-661sByA7TkR6Lmxt+hqV4h2SAt+7lgc58DzmUYArpEl1fQnMuQuaB0kQeHzi6fDD2+2G6o7EC+DuwBZKa479TA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.6.1.tgz",
+      "integrity": "sha512-GPI+mUiLm/B8eR7zXWIV252TQarN6Qv3S0wnJhs30gA8EI8/MkFkEgJFoKAKP7saV/r2gnONEZlovQvTuF0oqw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
+        "@parcel/plugin": "2.6.1",
         "json5": "^2.2.0"
       }
     },
     "@parcel/transformer-postcss": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.5.0.tgz",
-      "integrity": "sha512-IPNlWElekdQHMTBqhdwJNBCQomuYyo7xgNBdnTrt9VJ+R5ihy6n7ZJSWIAJXAH9VZxETTtunfrzRtgkmtjTeZQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.6.1.tgz",
+      "integrity": "sha512-NeZDXa9PkvHgwNWWtxaJWgGu7oq+jReCd1L/uXQRcNys2feUApdlQuKIjea1uL1UK6ydsS2kzmv/HqGWK3nGxA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -6062,13 +6199,13 @@
       }
     },
     "@parcel/transformer-posthtml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.5.0.tgz",
-      "integrity": "sha512-AZxg1XD8OXOS4bEGEmBBR+X9T9qoFdVsbVUg498zzejYSka1ZQHF7TgLI/+pUnE+ZVYNIp7/G0xXqsRVKMKmdQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.6.1.tgz",
+      "integrity": "sha512-XzfQf193m0RrlTzKDpqWWnS3ONn9xD9C8pKGvWapmrfFIMSwiOTY3EHUD8P3kCeon2CyddfshU1Y6yPkVdreww==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -6077,34 +6214,34 @@
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.5.0.tgz",
-      "integrity": "sha512-I3zjE1u9+Wj90Qqs1V2FTm6iC6SAyOVUthwVZkZey+qbQG/ok682Ez2XjLu7MyQCo9BJNwF/nfOa1hHr3MaJEQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.6.1.tgz",
+      "integrity": "sha512-gkuUksA8TDjaSlU9I2MFH4R3WfHXBOHLZlZ+juPK2rlLhhe8A/mvwOuWreNyjQTnKt6QXkdIkvgc9gTlsSHnXQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0"
+        "@parcel/plugin": "2.6.1"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.5.0.tgz",
-      "integrity": "sha512-VPqVBxhTN4OQwcjsdyxrv+smjAm4s6dbSWAplgPwdOITMv+a0tjhhJU37WnRC+xxTrbEqRcOt96JvGOkPb8i7g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.6.1.tgz",
+      "integrity": "sha512-EZg2OKsurEmvcCkbroL2v6sBk7X790BK7nlrCHug9EX8aatiwvabxBPlx9aRUwUEjqRBosmS+fmU1exKpqBZxA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/plugin": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/transformer-svg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.5.0.tgz",
-      "integrity": "sha512-zCGJcrCpICFe0Q/dgjQZfW7sYFkbJEC7NGT4zEJnMo8Cm/kq8Qh6+2ApX6c+vv5Q0WZn5Ic+N0OvxIMkvgdC/w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.6.1.tgz",
+      "integrity": "sha512-k9ccxU4eLMrmKDTdXbabq6C/TsF+bOSrWQYOC8QK+VPSF91S47vhVqLTiFeguB8bJGeLgd4uGS+YgdOLGjAJcw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/plugin": "2.6.1",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -6113,31 +6250,31 @@
       }
     },
     "@parcel/types": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
-      "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.1.tgz",
+      "integrity": "sha512-IXt0MiBmg95SKOAyvRNjcNlJvWUMtvCw6ea7+h1mWStm4gcJBoaznbgLJsG2C17AJ2F8CNR/5jZKlM9SDzTayg==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
+        "@parcel/cache": "2.6.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/fs": "2.6.1",
+        "@parcel/package-manager": "2.6.1",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.5.0",
+        "@parcel/workers": "2.6.1",
         "utility-types": "^3.10.0"
       }
     },
     "@parcel/utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
-      "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.1.tgz",
+      "integrity": "sha512-jMoNNBVGGs1IeNZnGGJv3R2otmf39X/0OerpuI27Ut4iCt79y6TVMFdoB7eG2aEYFdL6cD7xNfieQvX+6nrjoQ==",
       "dev": true,
       "requires": {
-        "@parcel/codeframe": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/markdown-ansi": "2.5.0",
+        "@parcel/codeframe": "2.6.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/hash": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/markdown-ansi": "2.6.1",
         "@parcel/source-map": "^2.0.0",
         "chalk": "^4.1.0"
       },
@@ -6204,23 +6341,23 @@
       }
     },
     "@parcel/workers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
-      "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.1.tgz",
+      "integrity": "sha512-KIXu5HAmnEDIDwwJDnLzlr0avsewux3rWHe/nN43ERgj2j5j1nVqIulE7tX+XKAM3AHTFKWHJi5RLX4Htl2wwg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/types": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@swc/helpers": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.13.tgz",
-      "integrity": "sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz",
+      "integrity": "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==",
       "requires": {
         "tslib": "^2.4.0"
       }
@@ -7139,15 +7276,6 @@
         "entities": "^3.0.1"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -7268,7 +7396,7 @@
     "is-json": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=",
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
       "dev": true
     },
     "is-map": {
@@ -7480,16 +7608,36 @@
       "dev": true
     },
     "lmdb": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-      "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
       "dev": true,
       "requires": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2",
         "msgpackr": "^1.5.4",
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
         "ordered-binary": "^1.2.4",
         "weak-lru-cache": "^1.2.2"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "dev": true
+        },
+        "node-gyp-build-optional-packages": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+          "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+          "dev": true
+        }
       }
     },
     "load-json-file": {
@@ -7512,12 +7660,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -7768,12 +7910,6 @@
       "dev": true,
       "optional": true
     },
-    "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true
-    },
     "nanoid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
@@ -7847,9 +7983,9 @@
       }
     },
     "nth-check": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
-      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
@@ -7930,21 +8066,21 @@
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
     },
     "parcel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.5.0.tgz",
-      "integrity": "sha512-er0mj/BaMjWyzQ/jedLUi/LNAuQcFT8lCvoNqANF+jTaX9rohaBwxIvKVJVAZgyCnmyfbbldp496wPMW0R0+CA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.6.1.tgz",
+      "integrity": "sha512-dqPG1u7NV/nlnoU6O9zO6sIFbna7b8IfmoNgMM0un2+EtOhNlz4bRp6U4AHosTulMUTKFmHpdXXG4dF9X0WQtw==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.5.0",
-        "@parcel/core": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/reporter-cli": "2.5.0",
-        "@parcel/reporter-dev-server": "2.5.0",
-        "@parcel/utils": "2.5.0",
+        "@parcel/config-default": "2.6.1",
+        "@parcel/core": "2.6.1",
+        "@parcel/diagnostic": "2.6.1",
+        "@parcel/events": "2.6.1",
+        "@parcel/fs": "2.6.1",
+        "@parcel/logger": "2.6.1",
+        "@parcel/package-manager": "2.6.1",
+        "@parcel/reporter-cli": "2.6.1",
+        "@parcel/reporter-dev-server": "2.6.1",
+        "@parcel/utils": "2.6.1",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0",
@@ -8123,12 +8259,6 @@
         "is-json": "^2.0.1"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8137,6 +8267,12 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+      "dev": true
     },
     "react-refresh": {
       "version": "0.9.0",
@@ -8239,12 +8375,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semver": {
@@ -8491,14 +8621,14 @@
       "dev": true
     },
     "terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
+      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
@@ -8507,15 +8637,6 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
         }
       }
     },
@@ -8533,7 +8654,7 @@
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
       "dev": true
     },
     "tiny-inflate": {
@@ -8548,15 +8669,6 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
       }
     },
     "tslib": {
@@ -8656,23 +8768,6 @@
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
   },
   "files": [
     "src",
-    "dist",
-    "iconv-lite.cjs"
+    "dist"
   ],
   "author": "Devon Govett <devongovett@gmail.com>",
   "license": "MIT",
@@ -92,8 +91,5 @@
     "npm-run-all": "^4.1.5",
     "parcel": "^2.6.1",
     "shx": "^0.3.4"
-  },
-  "alias": {
-    "./iconv-lite.cjs": "clone"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     "node": {
       "import": "./dist/module.mjs",
       "require": "./dist/main.cjs"
-    },
-    "import": "./dist/browser-module.mjs",
-    "require": "./dist/browser.cjs"
+    }
   },
   "targets": {
     "main": {
@@ -76,7 +74,7 @@
     "url": "git://github.com/foliojs/fontkit.git"
   },
   "dependencies": {
-    "@swc/helpers": "^0.3.17",
+    "@swc/helpers": "^0.4.2",
     "brotli": "^1.3.2",
     "clone": "^2.1.2",
     "deep-equal": "^2.0.5",
@@ -90,10 +88,9 @@
     "c8": "^7.11.3",
     "codepoints": "^1.2.0",
     "concat-stream": "^2.0.0",
-    "iconv-lite": "^0.4.24",
     "mocha": "^10.0.0",
     "npm-run-all": "^4.1.5",
-    "parcel": "2.5.0",
+    "parcel": "^2.6.1",
     "shx": "^0.3.4"
   },
   "alias": {

--- a/package.json
+++ b/package.json
@@ -24,16 +24,43 @@
   },
   "type": "module",
   "main": "dist/main.cjs",
-  "module": "dist/module.mjs",
+  "node-module": "dist/module.mjs",
+  "browser": "dist/browser.cjs",
+  "module": "dist/browser-module.mjs",
   "source": "src/index.js",
   "exports": {
-    "import": "./dist/module.mjs",
-    "require": "./dist/main.cjs"
+    "node": {
+      "import": "./dist/module.mjs",
+      "require": "./dist/main.cjs"
+    },
+    "import": "./dist/browser-module.mjs",
+    "require": "./dist/browser.cjs"
   },
   "targets": {
     "main": {
+      "source": "src/node.js",
       "engines": {
-        "browsers": "Chrome 70"
+        "chrome": "70"
+      }
+    },
+    "node-module": {
+      "source": "src/node.js",
+      "isLibrary": true,
+      "includeNodeModules": false,
+      "engines": {
+        "chrome": "70"
+      }
+    },
+    "module": {
+      "source": "src/index.js",
+      "engines": {
+        "chrome": "70"
+      }
+    },
+    "browser": {
+      "source": "src/index.js",
+      "engines": {
+        "chrome": "70"
       }
     }
   },
@@ -49,7 +76,7 @@
     "url": "git://github.com/foliojs/fontkit.git"
   },
   "dependencies": {
-    "@swc/helpers": "^0.3.13",
+    "@swc/helpers": "^0.3.17",
     "brotli": "^1.3.2",
     "clone": "^2.1.2",
     "deep-equal": "^2.0.5",
@@ -66,7 +93,7 @@
     "iconv-lite": "^0.4.24",
     "mocha": "^10.0.0",
     "npm-run-all": "^4.1.5",
-    "parcel": "^2.5.0",
+    "parcel": "2.5.0",
     "shx": "^0.3.4"
   },
   "alias": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,15 @@
     "node": {
       "import": "./dist/module.mjs",
       "require": "./dist/main.cjs"
-    }
+    },
+    "import": "./dist/browser-module.mjs",
+    "require": "./dist/browser.cjs"
   },
   "targets": {
     "main": {
       "source": "src/node.js",
       "engines": {
-        "chrome": "70"
+        "browsers": "chrome >= 70"
       }
     },
     "node-module": {
@@ -46,19 +48,19 @@
       "isLibrary": true,
       "includeNodeModules": false,
       "engines": {
-        "chrome": "70"
+        "browsers": "chrome >= 70"
       }
     },
     "module": {
       "source": "src/index.js",
       "engines": {
-        "chrome": "70"
+        "browsers": "chrome >= 70"
       }
     },
     "browser": {
       "source": "src/index.js",
       "engines": {
-        "chrome": "70"
+        "browsers": "chrome >= 70"
       }
     }
   },

--- a/src/DFont.js
+++ b/src/DFont.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import TTFFont from './TTFFont';
 
 let DFontName = new r.String(r.uint8);
@@ -89,8 +89,16 @@ export default class DFont {
       let pos = this.header.dataOffset + ref.dataOffset + 4;
       let stream = new r.DecodeStream(this.stream.buffer.slice(pos));
       let font = new TTFFont(stream);
-      if ((Buffer.isBuffer(font.postscriptName) && font.postscriptName.equals(name)) || font.postscriptName === name)
+      if (
+        font.postscriptName === name ||
+        (
+          font.postscriptName instanceof Uint8Array && 
+          name instanceof Uint8Array && 
+          font.postscriptName.every((v, i) => name[i] === v)
+        )
+      ) {
         return font;
+      }
     }
 
     return null;

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import { cache } from './decorators';
 import * as fontkit from './base';
 import Directory from './tables/directory';
@@ -13,6 +13,7 @@ import GlyphVariationProcessor from './glyph/GlyphVariationProcessor';
 import TTFSubset from './subset/TTFSubset';
 import CFFSubset from './subset/CFFSubset';
 import BBox from './glyph/BBox';
+import { asciiDecoder } from './utils';
 
 /**
  * This is the base class for all SFNT-based font formats in fontkit.
@@ -22,7 +23,7 @@ export default class TTFFont {
   type = 'TTF';
 
   static probe(buffer) {
-    let format = buffer.toString('ascii', 0, 4);
+    let format = asciiDecoder.decode(buffer.slice(0, 4));
     return format === 'true' || format === 'OTTO' || format === String.fromCharCode(0, 1, 0, 0);
   }
 

--- a/src/TrueTypeCollection.js
+++ b/src/TrueTypeCollection.js
@@ -1,7 +1,8 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import TTFFont from './TTFFont';
 import Directory from './tables/directory';
 import tables from './tables';
+import { asciiDecoder } from './utils';
 
 let TTCHeader = new r.VersionedStruct(r.uint32, {
   0x00010000: {
@@ -21,7 +22,7 @@ export default class TrueTypeCollection {
   type = 'TTC';
 
   static probe(buffer) {
-    return buffer.toString('ascii', 0, 4) === 'ttcf';
+    return asciiDecoder.decode(buffer.slice(0, 4)) === 'ttcf';
   }
 
   constructor(stream) {
@@ -38,8 +39,16 @@ export default class TrueTypeCollection {
       let stream = new r.DecodeStream(this.stream.buffer);
       stream.pos = offset;
       let font = new TTFFont(stream);
-      if ((Buffer.isBuffer(font.postscriptName) && font.postscriptName.equals(name)) || font.postscriptName === name)
+      if (
+        font.postscriptName === name ||
+        (
+          font.postscriptName instanceof Uint8Array && 
+          name instanceof Uint8Array && 
+          font.postscriptName.every((v, i) => name[i] === v)
+        )
+      ) {
         return font;
+      }
     }
 
     return null;

--- a/src/WOFF2Font.js
+++ b/src/WOFF2Font.js
@@ -1,9 +1,10 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import brotli from 'brotli/decompress.js';
 import TTFFont from './TTFFont';
 import TTFGlyph, { Point } from './glyph/TTFGlyph';
 import WOFF2Glyph from './glyph/WOFF2Glyph';
 import WOFF2Directory from './tables/WOFF2Directory';
+import { asciiDecoder } from './utils';
 
 /**
  * Subclass of TTFFont that represents a TTF/OTF font compressed by WOFF2
@@ -13,7 +14,7 @@ export default class WOFF2Font extends TTFFont {
   type = 'WOFF2';
 
   static probe(buffer) {
-    return buffer.toString('ascii', 0, 4) === 'wOF2';
+    return asciiDecoder.decode(buffer.slice(0, 4)) === 'wOF2';
   }
 
   _decodeDirectory() {
@@ -39,7 +40,7 @@ export default class WOFF2Font extends TTFFont {
         throw new Error('Error decoding compressed data in WOFF2');
       }
 
-      this.stream = new r.DecodeStream(Buffer.from(decompressed));
+      this.stream = new r.DecodeStream(decompressed);
       this._decompressed = true;
     }
   }

--- a/src/WOFFFont.js
+++ b/src/WOFFFont.js
@@ -2,13 +2,14 @@ import TTFFont from './TTFFont';
 import WOFFDirectory from './tables/WOFFDirectory';
 import tables from './tables';
 import inflate from 'tiny-inflate';
-import r from 'restructure';
+import * as r from 'restructure';
+import { asciiDecoder } from './utils';
 
 export default class WOFFFont extends TTFFont {
   type = 'WOFF';
 
   static probe(buffer) {
-    return buffer.toString('ascii', 0, 4) === 'wOFF';
+    return asciiDecoder.decode(buffer.slice(0, 4)) === 'wOFF';
   }
 
   _decodeDirectory() {
@@ -22,7 +23,7 @@ export default class WOFFFont extends TTFFont {
 
       if (table.compLength < table.length) {
         this.stream.pos += 2; // skip deflate header
-        let outBuffer = Buffer.alloc(table.length);
+        let outBuffer = new Uint8Array(table.length);
         let buf = inflate(this.stream.readBuffer(table.compLength - 2), outBuffer);
         return new r.DecodeStream(buf);
       } else {

--- a/src/base.js
+++ b/src/base.js
@@ -1,37 +1,10 @@
-import r from 'restructure';
-const fs = require('fs');
+import * as r from 'restructure';
 
 export let logErrors = false;
 
 let formats = [];
 export function registerFormat(format) {
   formats.push(format);
-};
-
-export function openSync(filename, postscriptName) {
-  let buffer = fs.readFileSync(filename);
-  return create(buffer, postscriptName);
-};
-
-export function open(filename, postscriptName, callback) {
-  if (typeof postscriptName === 'function') {
-    callback = postscriptName;
-    postscriptName = null;
-  }
-
-  fs.readFile(filename, function (err, buffer) {
-    if (err) { return callback(err); }
-
-    try {
-      var font = create(buffer, postscriptName);
-    } catch (e) {
-      return callback(e);
-    }
-
-    return callback(null, font);
-  });
-
-  return;
 };
 
 export function create(buffer, postscriptName) {

--- a/src/base.js
+++ b/src/base.js
@@ -1,4 +1,4 @@
-import * as r from 'restructure';
+import {DecodeStream} from 'restructure';
 
 export let logErrors = false;
 
@@ -11,7 +11,7 @@ export function create(buffer, postscriptName) {
   for (let i = 0; i < formats.length; i++) {
     let format = formats[i];
     if (format.probe(buffer)) {
-      let font = new format(new r.DecodeStream(buffer));
+      let font = new format(new DecodeStream(buffer));
       if (postscriptName) {
         return font.getFont(postscriptName);
       }

--- a/src/cff/CFFDict.js
+++ b/src/cff/CFFDict.js
@@ -1,7 +1,7 @@
 import isEqual from 'deep-equal';
-import r from 'restructure';
+import * as r from 'restructure';
 import CFFOperand from './CFFOperand';
-import { PropertyDescriptor } from 'restructure/src/utils.js';
+import { PropertyDescriptor } from 'restructure';
 
 export default class CFFDict {
   constructor(ops = []) {

--- a/src/cff/CFFFont.js
+++ b/src/cff/CFFFont.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import CFFIndex from './CFFIndex';
 import CFFTop from './CFFTop';
 import CFFPrivateDict from './CFFPrivateDict';

--- a/src/cff/CFFIndex.js
+++ b/src/cff/CFFIndex.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 export default class CFFIndex {
   constructor(type) {

--- a/src/cff/CFFPointer.js
+++ b/src/cff/CFFPointer.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 export default class CFFPointer extends r.Pointer {
   constructor(type, options = {}) {

--- a/src/cff/CFFTop.js
+++ b/src/cff/CFFTop.js
@@ -1,5 +1,5 @@
-import r from 'restructure';
-import { resolveLength } from 'restructure/src/utils.js';
+import * as r from 'restructure';
+import { resolveLength } from 'restructure';
 import CFFDict from './CFFDict';
 import CFFIndex from './CFFIndex';
 import CFFPointer from './CFFPointer';

--- a/src/encodings.js
+++ b/src/encodings.js
@@ -10,6 +10,59 @@ export function getEncoding(platformID, encodingID, languageID = 0) {
   return ENCODINGS[platformID][encodingID];
 }
 
+const SINGLE_BYTE_ENCODINGS = new Set(['x-mac-roman', 'x-mac-cyrillic', 'iso-8859-6', 'iso-8859-8']);
+const MAC_ENCODINGS = {
+  'x-mac-croatian': 'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûü†°¢£§•¶ß®Š™´¨≠ŽØ∞±≤≥∆µ∂∑∏š∫ªºΩžø¿¡¬√ƒ≈Ć«Č… ÀÃÕŒœĐ—“”‘’÷◊©⁄€‹›Æ»–·‚„‰ÂćÁčÈÍÎÏÌÓÔđÒÚÛÙıˆ˜¯πË˚¸Êæˇ',
+  'x-mac-gaelic': 'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûü†°¢£§•¶ß®©™´¨≠ÆØḂ±≤≥ḃĊċḊḋḞḟĠġṀæøṁṖṗɼƒſṠ«»… ÀÃÕŒœ–—“”‘’ṡẛÿŸṪ€‹›Ŷŷṫ·Ỳỳ⁊ÂÊÁËÈÍÎÏÌÓÔ♣ÒÚÛÙıÝýŴŵẄẅẀẁẂẃ',
+  'x-mac-greek': 'Ä¹²É³ÖÜ΅àâä΄¨çéèêë£™îï•½‰ôö¦€ùûü†ΓΔΘΛΞΠß®©ΣΪ§≠°·Α±≤≥¥ΒΕΖΗΙΚΜΦΫΨΩάΝ¬ΟΡ≈Τ«»… ΥΧΆΈœ–―“”‘’÷ΉΊΌΎέήίόΏύαβψδεφγηιξκλμνοπώρστθωςχυζϊϋΐΰ\u00AD',
+  'x-mac-icelandic': 'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûüÝ°¢£§•¶ß®©™´¨≠ÆØ∞±≤≥¥µ∂∑∏π∫ªºΩæø¿¡¬√ƒ≈∆«»… ÀÃÕŒœ–—“”‘’÷◊ÿŸ⁄€ÐðÞþý·‚„‰ÂÊÁËÈÍÎÏÌÓÔÒÚÛÙıˆ˜¯˘˙˚¸˝˛ˇ',
+  'x-mac-inuit': 'ᐃᐄᐅᐆᐊᐋᐱᐲᐳᐴᐸᐹᑉᑎᑏᑐᑑᑕᑖᑦᑭᑮᑯᑰᑲᑳᒃᒋᒌᒍᒎᒐᒑ°ᒡᒥᒦ•¶ᒧ®©™ᒨᒪᒫᒻᓂᓃᓄᓅᓇᓈᓐᓯᓰᓱᓲᓴᓵᔅᓕᓖᓗᓘᓚᓛᓪᔨᔩᔪᔫᔭ… ᔮᔾᕕᕖᕗ–—“”‘’ᕘᕙᕚᕝᕆᕇᕈᕉᕋᕌᕐᕿᖀᖁᖂᖃᖄᖅᖏᖐᖑᖒᖓᖔᖕᙱᙲᙳᙴᙵᙶᖖᖠᖡᖢᖣᖤᖥᖦᕼŁł',
+  'x-mac-ce': 'ÄĀāÉĄÖÜáąČäčĆćéŹźĎíďĒēĖóėôöõúĚěü†°Ę£§•¶ß®©™ę¨≠ģĮįĪ≤≥īĶ∂∑łĻļĽľĹĺŅņŃ¬√ńŇ∆«»… ňŐÕőŌ–—“”‘’÷◊ōŔŕŘ‹›řŖŗŠ‚„šŚśÁŤťÍŽžŪÓÔūŮÚůŰűŲųÝýķŻŁżĢˇ',
+  'x-mac-romanian': 'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûü†°¢£§•¶ß®©™´¨≠ĂȘ∞±≤≥¥µ∂∑∏π∫ªºΩăș¿¡¬√ƒ≈∆«»… ÀÃÕŒœ–—“”‘’÷◊ÿŸ⁄€‹›Țț‡·‚„‰ÂÊÁËÈÍÎÏÌÓÔÒÚÛÙıˆ˜¯˘˙˚¸˝˛ˇ',
+  'x-mac-turkish': 'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûü†°¢£§•¶ß®©™´¨≠ÆØ∞±≤≥¥µ∂∑∏π∫ªºΩæø¿¡¬√ƒ≈∆«»… ÀÃÕŒœ–—“”‘’÷◊ÿŸĞğİıŞş‡·‚„‰ÂÊÁËÈÍÎÏÌÓÔÒÚÛÙˆ˜¯˘˙˚¸˝˛ˇ'
+};
+
+const encodingCache = new Map();
+
+export function getEncodingMapping(encoding) {
+  let cached = encodingCache.get(encoding);
+  if (cached) {
+    return cached;
+  }
+
+  // These encodings aren't supported by TextDecoder.
+  let mapping = MAC_ENCODINGS[encoding];
+  if (mapping) {
+    let res = new Map();
+    for (let i = 0; i < mapping.length; i++) {
+      res.set(mapping.charCodeAt(i), 0x80 + i);
+    }
+
+    encodingCache.set(encoding, res);
+    return res;
+  }
+
+  // Only single byte encodings can be mapped 1:1.
+  if (SINGLE_BYTE_ENCODINGS.has(encoding)) {
+    // TextEncoder only supports utf8, whereas TextDecoder supports legacy encodings.
+    // Use this to create a mapping of code points.
+    let decoder = new TextDecoder(encoding);
+    let mapping = new Uint8Array(0x80);
+    for (let i = 0; i < 0x80; i++) {
+      mapping[i] = 0x80 + i;
+    }
+
+    let res = new Map();
+    let s = decoder.decode(mapping);
+    for (let i = 0; i < 0x80; i++) {
+      res.set(s.charCodeAt(i), 0x80 + i);
+    }
+
+    encodingCache.set(encoding, res);
+    return res;
+  }
+}
+
 // Map of platform ids to encoding ids.
 export const ENCODINGS = [
   // unicode
@@ -34,38 +87,38 @@ export const ENCODINGS = [
   // 14	Tamil	                31	Sindhi
   // 15	Telugu	              32	(Uninterpreted)
   // 16	Kannada
-  ['macroman', 'shift-jis', 'big5', 'euc-kr', 'iso-8859-6', 'iso-8859-8',
-   'macgreek', 'maccyrillic', 'symbol', 'Devanagari', 'Gurmukhi', 'Gujarati',
+  ['x-mac-roman', 'shift-jis', 'big5', 'euc-kr', 'iso-8859-6', 'iso-8859-8',
+   'x-mac-greek', 'x-mac-cyrillic', 'x-mac-symbol', 'x-mac-devanagari', 'x-mac-gurmukhi', 'x-mac-gujarati',
    'Oriya', 'Bengali', 'Tamil', 'Telugu', 'Kannada', 'Malayalam', 'Sinhalese',
-   'Burmese', 'Khmer', 'macthai', 'Laotian', 'Georgian', 'Armenian', 'gb-2312-80', 
-   'Tibetan', 'Mongolian', 'Geez', 'maccenteuro', 'Vietnamese', 'Sindhi'],
+   'Burmese', 'Khmer', 'iso-8859-11', 'Laotian', 'Georgian', 'Armenian', 'hz-gb-2312', 
+   'Tibetan', 'Mongolian', 'Geez', 'x-mac-ce', 'Vietnamese', 'Sindhi'],
   
   // ISO (deprecated)
   ['ascii'],
   
   // windows
   // Docs here: http://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx
-  ['symbol', 'utf16be', 'shift-jis', 'gb18030', 'big5', 'wansung', 'johab', null, null, null, 'utf16be']
+  ['symbol', 'utf16be', 'shift-jis', 'gb18030', 'big5', 'x-cp20949', 'johab', null, null, null, 'utf16be']
 ];
 
 // Overrides for Mac scripts by language id.
 // See http://unicode.org/Public/MAPPINGS/VENDORS/APPLE/Readme.txt
 export const MAC_LANGUAGE_ENCODINGS = {
-  15: 'maciceland',
-  17: 'macturkish',
-  18: 'maccroatian',
-  24: 'maccenteuro',
-  25: 'maccenteuro',
-  26: 'maccenteuro',
-  27: 'maccenteuro',
-  28: 'maccenteuro',
-  30: 'maciceland',
-  37: 'macromania',
-  38: 'maccenteuro',
-  39: 'maccenteuro',
-  40: 'maccenteuro',
-  143: 'macinuit', // Unsupported by iconv-lite
-  146: 'macgaelic' // Unsupported by iconv-lite
+  15: 'x-mac-icelandic',
+  17: 'x-mac-turkish',
+  18: 'x-mac-croatian',
+  24: 'x-mac-ce',
+  25: 'x-mac-ce',
+  26: 'x-mac-ce',
+  27: 'x-mac-ce',
+  28: 'x-mac-ce',
+  30: 'x-mac-icelandic',
+  37: 'x-mac-romanian',
+  38: 'x-mac-ce',
+  39: 'x-mac-ce',
+  40: 'x-mac-ce',
+  143: 'x-mac-inuit',
+  146: 'x-mac-gaelic'
 };
 
 // Map of platform ids to BCP-47 language codes.

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,0 +1,28 @@
+import { create } from './base';
+import fs from 'fs';
+
+export function openSync(filename, postscriptName) {
+  let buffer = fs.readFileSync(filename);
+  return create(buffer, postscriptName);
+}
+
+export function open(filename, postscriptName, callback) {
+  if (typeof postscriptName === 'function') {
+    callback = postscriptName;
+    postscriptName = null;
+  }
+
+  fs.readFile(filename, function (err, buffer) {
+    if (err) { return callback(err); }
+
+    try {
+      var font = create(buffer, postscriptName);
+    } catch (e) {
+      return callback(e);
+    }
+
+    return callback(null, font);
+  });
+
+  return;
+}

--- a/src/fs.js
+++ b/src/fs.js
@@ -6,23 +6,12 @@ export function openSync(filename, postscriptName) {
   return create(buffer, postscriptName);
 }
 
-export function open(filename, postscriptName, callback) {
+export async function open(filename, postscriptName, callback) {
   if (typeof postscriptName === 'function') {
     callback = postscriptName;
     postscriptName = null;
   }
 
-  fs.readFile(filename, function (err, buffer) {
-    if (err) { return callback(err); }
-
-    try {
-      var font = create(buffer, postscriptName);
-    } catch (e) {
-      return callback(e);
-    }
-
-    return callback(null, font);
-  });
-
-  return;
+  let buffer = await fs.promises.readFile(filename);
+  return create(buffer, postscriptName);
 }

--- a/src/glyph/SBIXGlyph.js
+++ b/src/glyph/SBIXGlyph.js
@@ -1,5 +1,5 @@
 import TTFGlyph from './TTFGlyph';
-import r from 'restructure';
+import * as r from 'restructure';
 
 let SBIXImage = new r.Struct({
   originX: r.uint16,

--- a/src/glyph/TTFGlyph.js
+++ b/src/glyph/TTFGlyph.js
@@ -1,7 +1,7 @@
 import Glyph from './Glyph';
 import Path from './Path';
 import BBox from './BBox';
-import r from 'restructure';
+import * as r from 'restructure';
 
 // The header for both simple and composite glyphs
 let GlyfHeader = new r.Struct({

--- a/src/glyph/TTFGlyphEncoder.js
+++ b/src/glyph/TTFGlyphEncoder.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // Flags for simple glyphs
 const ON_CURVE        = 1 << 0;

--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,3 @@ registerFormat(TrueTypeCollection);
 registerFormat(DFont);
 
 export * from './base';
-
-// Legacy default export for backward compatibility.
-export default {
-  registerFormat,
-  create,
-  defaultLanguage,
-  setDefaultLanguage
-};

--- a/src/node.js
+++ b/src/node.js
@@ -1,4 +1,5 @@
 import { registerFormat, create, defaultLanguage, setDefaultLanguage } from './base';
+import { open, openSync } from './fs';
 import TTFFont from './TTFFont';
 import WOFFFont from './WOFFFont';
 import WOFF2Font from './WOFF2Font';
@@ -13,11 +14,14 @@ registerFormat(TrueTypeCollection);
 registerFormat(DFont);
 
 export * from './base';
+export * from './fs';
 
 // Legacy default export for backward compatibility.
 export default {
   registerFormat,
   create,
+  open,
+  openSync,
   defaultLanguage,
   setDefaultLanguage
 };

--- a/src/node.js
+++ b/src/node.js
@@ -15,13 +15,3 @@ registerFormat(DFont);
 
 export * from './base';
 export * from './fs';
-
-// Legacy default export for backward compatibility.
-export default {
-  registerFormat,
-  create,
-  open,
-  openSync,
-  defaultLanguage,
-  setDefaultLanguage
-};

--- a/src/opentype/shapers/ArabicShaper.js
+++ b/src/opentype/shapers/ArabicShaper.js
@@ -1,8 +1,9 @@
 import DefaultShaper from './DefaultShaper';
 import unicode from 'unicode-properties';
 import UnicodeTrie from 'unicode-trie';
+import { decodeBase64 } from '../../utils';
 
-const trie = new UnicodeTrie(require('fs').readFileSync(__dirname + '/data.trie'));
+const trie = new UnicodeTrie(decodeBase64(require('fs').readFileSync(__dirname + '/data.trie', 'base64')));
 const FEATURES = ['isol', 'fina', 'fin2', 'fin3', 'medi', 'med2', 'init'];
 
 const ShapingClasses = {

--- a/src/opentype/shapers/IndicShaper.js
+++ b/src/opentype/shapers/IndicShaper.js
@@ -14,9 +14,10 @@ import {
   HALANT_OR_COENG_FLAGS, INDIC_CONFIGS,
   INDIC_DECOMPOSITIONS
 } from './indic-data';
+import { decodeBase64 } from '../../utils';
 
 const {decompositions} = useData;
-const trie = new UnicodeTrie(require('fs').readFileSync(__dirname + '/indic.trie'));
+const trie = new UnicodeTrie(decodeBase64(require('fs').readFileSync(__dirname + '/indic.trie', 'base64')));
 const stateMachine = new StateMachine(indicMachine);
 
 /**

--- a/src/opentype/shapers/UniversalShaper.js
+++ b/src/opentype/shapers/UniversalShaper.js
@@ -3,9 +3,10 @@ import StateMachine from 'dfa';
 import UnicodeTrie from 'unicode-trie';
 import GlyphInfo from '../GlyphInfo';
 import useData from './use.json';
+import { decodeBase64 } from '../../utils';
 
 const {categories, decompositions} = useData;
-const trie = new UnicodeTrie(require('fs').readFileSync(__dirname + '/use.trie'));
+const trie = new UnicodeTrie(decodeBase64(require('fs').readFileSync(__dirname + '/use.trie', 'base64')));
 const stateMachine = new StateMachine(useData);
 
 /**

--- a/src/subset/CFFSubset.js
+++ b/src/subset/CFFSubset.js
@@ -39,7 +39,7 @@ export default class CFFSubset extends Subset {
         this.cff.stream.pos = subr.offset;
         res.push(this.cff.stream.readBuffer(subr.length));
       } else {
-        res.push(Buffer.from([11])); // return
+        res.push(new Uint8Array([11])); // return
       }
     }
 
@@ -128,7 +128,7 @@ export default class CFFSubset extends Subset {
     return standardStrings.length + this.strings.length - 1;
   }
 
-  encode(stream) {
+  encode() {
     this.subsetCharstrings();
 
     let charset = {
@@ -166,6 +166,6 @@ export default class CFFSubset extends Subset {
       globalSubrIndex: this.gsubrs
     };
 
-    CFFTop.encode(stream, top);
+    return CFFTop.toBuffer(top);
   }
 }

--- a/src/subset/Subset.js
+++ b/src/subset/Subset.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 const resolved = Promise.resolve();
 
@@ -23,16 +23,5 @@ export default class Subset {
     }
 
     return this.mapping[glyph];
-  }
-
-  encodeStream() {
-    let s = new r.EncodeStream();
-
-    resolved.then(() => {
-      this.encode(s);
-      return s.end();
-    });
-
-    return s;
   }
 }

--- a/src/subset/TTFSubset.js
+++ b/src/subset/TTFSubset.js
@@ -25,10 +25,11 @@ export default class TTFSubset extends Subset {
 
     // if it is a compound glyph, include its components
     if (glyf && glyf.numberOfContours < 0) {
-      buffer = Buffer.from(buffer);
+      buffer = new Uint8Array(buffer);
+      let view = new DataView(buffer.buffer);
       for (let component of glyf.components) {
         gid = this.includeGlyph(component.glyphID);
-        buffer.writeUInt16BE(gid, component.pos);
+        view.setUint16(component.pos, gid);
       }
     } else if (glyf && this.font._variationProcessor) {
       // If this is a TrueType variation glyph, re-encode the path
@@ -47,7 +48,7 @@ export default class TTFSubset extends Subset {
     return this.glyf.length - 1;
   }
 
-  encode(stream) {
+  encode() {
     // tables required by PDF spec:
     //   head, hhea, loca, maxp, cvt , prep, glyf, hmtx, fpgm
     //
@@ -108,7 +109,7 @@ export default class TTFSubset extends Subset {
     //     ]
 
     // TODO: subset prep, cvt, fpgm?
-    Directory.encode(stream, {
+    return Directory.toBuffer({
       tables: {
         head,
         hhea,

--- a/src/tables/BASE.js
+++ b/src/tables/BASE.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device} from './opentype';
 import {ItemVariationStore} from './variations';
 

--- a/src/tables/COLR.js
+++ b/src/tables/COLR.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let LayerRecord = new r.Struct({
   gid: r.uint16,          // Glyph ID of layer glyph (must be in z-order from bottom to top).

--- a/src/tables/CPAL.js
+++ b/src/tables/CPAL.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let ColorRecord = new r.Struct({
   blue: r.uint8,

--- a/src/tables/DSIG.js
+++ b/src/tables/DSIG.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let Signature = new r.Struct({
   format: r.uint32,

--- a/src/tables/EBDT.js
+++ b/src/tables/EBDT.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 export let BigMetrics = new r.Struct({
   height: r.uint8,

--- a/src/tables/EBLC.js
+++ b/src/tables/EBLC.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import {BigMetrics} from './EBDT';
 
 let SBitLineMetrics = new r.Struct({

--- a/src/tables/GDEF.js
+++ b/src/tables/GDEF.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device} from './opentype';
 import {ItemVariationStore} from './variations';
 

--- a/src/tables/GPOS.js
+++ b/src/tables/GPOS.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device, Context, ChainingContext} from './opentype';
 import {FeatureVariations} from './variations';
 

--- a/src/tables/GSUB.js
+++ b/src/tables/GSUB.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device, Context, ChainingContext} from './opentype';
 import {FeatureVariations} from './variations';
 

--- a/src/tables/HVAR.js
+++ b/src/tables/HVAR.js
@@ -1,5 +1,5 @@
-import r from 'restructure';
-import { resolveLength } from 'restructure/src/utils.js';
+import * as r from 'restructure';
+import { resolveLength } from 'restructure';
 import { ItemVariationStore } from './variations';
 
 // TODO: add this to restructure

--- a/src/tables/JSTF.js
+++ b/src/tables/JSTF.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import { ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device } from './opentype';
 import { GPOSLookup } from './GPOS';
 

--- a/src/tables/LTSH.js
+++ b/src/tables/LTSH.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // Linear Threshold table
 // Records the ppem for each glyph at which the scaling becomes linear again,

--- a/src/tables/OS2.js
+++ b/src/tables/OS2.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 var OS2 = new r.VersionedStruct(r.uint16, {
   header: {

--- a/src/tables/PCLT.js
+++ b/src/tables/PCLT.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // PCL 5 Table
 // NOTE: The PCLT table is strongly discouraged for OpenType fonts with TrueType outlines

--- a/src/tables/VDMX.js
+++ b/src/tables/VDMX.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // VDMX tables contain ascender/descender overrides for certain (usually small)
 // sizes. This is needed in order to match font metrics on Windows.

--- a/src/tables/VORG.js
+++ b/src/tables/VORG.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let VerticalOrigin = new r.Struct({
   glyphIndex:   r.uint16,

--- a/src/tables/WOFF2Directory.js
+++ b/src/tables/WOFF2Directory.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 const Base128 = {
   decode(stream) {

--- a/src/tables/WOFFDirectory.js
+++ b/src/tables/WOFFDirectory.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import tables from './';
 
 let WOFFDirectoryEntry = new r.Struct({

--- a/src/tables/aat.js
+++ b/src/tables/aat.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 class UnboundedArrayAccessor {
   constructor(type, stream, parent) {

--- a/src/tables/avar.js
+++ b/src/tables/avar.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let shortFrac = new r.Fixed(16, 'BE', 14);
 

--- a/src/tables/bsln.js
+++ b/src/tables/bsln.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import { LookupTable } from './aat';
 
 let BslnSubtable = new r.VersionedStruct('format', {

--- a/src/tables/cmap.js
+++ b/src/tables/cmap.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let SubHeader = new r.Struct({
   firstCode:      r.uint16,

--- a/src/tables/cvt.js
+++ b/src/tables/cvt.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // An array of predefined values accessible by instructions
 export default new r.Struct({

--- a/src/tables/directory.js
+++ b/src/tables/directory.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import Tables from './';
 
 let TableEntry = new r.Struct({
@@ -26,23 +26,26 @@ Directory.process = function() {
   this.tables = tables;
 };
 
-Directory.preEncode = function(stream) {
-  let tables = [];
-  for (let tag in this.tables) {
-    let table = this.tables[tag];
-    if (table) {
-      tables.push({
-        tag: tag,
-        checkSum: 0,
-        offset: new r.VoidPointer(Tables[tag], table),
-        length: Tables[tag].size(table)
-      });
+Directory.preEncode = function() {
+  if (!Array.isArray(this.tables)) {
+    let tables = [];
+    for (let tag in this.tables) {
+      let table = this.tables[tag];
+      if (table) {
+        tables.push({
+          tag: tag,
+          checkSum: 0,
+          offset: new r.VoidPointer(Tables[tag], table),
+          length: Tables[tag].size(table)
+        });
+      }
     }
+    
+    this.tables = tables;
   }
 
   this.tag = 'true';
-  this.numTables = tables.length;
-  this.tables = tables;
+  this.numTables = this.tables.length;
 
   let maxExponentFor2 = Math.floor((Math.log(this.numTables) / Math.LN2));
   let maxPowerOf2 = Math.pow(2, maxExponentFor2);

--- a/src/tables/feat.js
+++ b/src/tables/feat.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let Setting = new r.Struct({
   setting: r.uint16,

--- a/src/tables/fpgm.js
+++ b/src/tables/fpgm.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // A list of instructions that are executed once when a font is first used.
 // These instructions are known as the font program. The main use of this table

--- a/src/tables/fvar.js
+++ b/src/tables/fvar.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let Axis = new r.Struct({
   axisTag: new r.String(4),

--- a/src/tables/gasp.js
+++ b/src/tables/gasp.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let GaspRange = new r.Struct({
   rangeMaxPPEM:       r.uint16,                  // Upper limit of range, in ppem

--- a/src/tables/glyf.js
+++ b/src/tables/glyf.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // only used for encoding
 export default new r.Array(new r.Buffer);

--- a/src/tables/gvar.js
+++ b/src/tables/gvar.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let shortFrac = new r.Fixed(16, 'BE', 14);
 class Offset {

--- a/src/tables/hdmx.js
+++ b/src/tables/hdmx.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let DeviceRecord = new r.Struct({
   pixelSize:      r.uint8,

--- a/src/tables/head.js
+++ b/src/tables/head.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // font header
 export default new r.Struct({

--- a/src/tables/hhea.js
+++ b/src/tables/hhea.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // horizontal header
 export default new r.Struct({

--- a/src/tables/hmtx.js
+++ b/src/tables/hmtx.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let HmtxEntry = new r.Struct({
   advance: r.uint16,

--- a/src/tables/just.js
+++ b/src/tables/just.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import { LookupTable, StateTable1 } from './aat';
 
 let ClassTable = new r.Struct({

--- a/src/tables/kern.js
+++ b/src/tables/kern.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let KernPair = new r.Struct({
   left:   r.uint16,

--- a/src/tables/loca.js
+++ b/src/tables/loca.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let loca = new r.VersionedStruct('head.indexToLocFormat', {
   0: {
@@ -10,18 +10,20 @@ let loca = new r.VersionedStruct('head.indexToLocFormat', {
 });
 
 loca.process = function() {
-  if (this.version === 0) {
+  if (this.version === 0 && !this._processed) {
     for (let i = 0; i < this.offsets.length; i++) {
       this.offsets[i] <<= 1;
     }
+    this._processed = true;
   }
 };
 
 loca.preEncode = function() {
-  if (this.version === 0) {
+  if (this.version === 0 && this._processed !== false) {
     for (let i = 0; i < this.offsets.length; i++) {
       this.offsets[i] >>>= 1;
     }
+    this._processed = false;
   }
 };
 

--- a/src/tables/maxp.js
+++ b/src/tables/maxp.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // maxiumum profile
 export default new r.Struct({

--- a/src/tables/morx.js
+++ b/src/tables/morx.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import { UnboundedArray, LookupTable, StateTable } from './aat';
 
 let LigatureData = {

--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import {getEncoding, LANGUAGES} from '../encodings';
 
 let NameRecord = new r.Struct({
@@ -108,7 +108,7 @@ NameTable.preEncode = function() {
       encodingID: 1,
       languageID: 0x409,
       nameID: NAMES.indexOf(key),
-      length: Buffer.byteLength(val.en, 'utf16le'),
+      length: val.en.length * 2,
       string: val.en
     });
 

--- a/src/tables/opbd.js
+++ b/src/tables/opbd.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 import { LookupTable } from './aat';
 
 let OpticalBounds = new r.Struct({

--- a/src/tables/opentype.js
+++ b/src/tables/opentype.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 //########################
 // Scripts and Languages #

--- a/src/tables/post.js
+++ b/src/tables/post.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // PostScript information
 export default new r.VersionedStruct(r.fixed32, {

--- a/src/tables/prep.js
+++ b/src/tables/prep.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // Set of instructions executed whenever the point size or font transformation change
 export default new r.Struct({

--- a/src/tables/sbix.js
+++ b/src/tables/sbix.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let ImageTable = new r.Struct({
   ppem: r.uint16,

--- a/src/tables/variations.js
+++ b/src/tables/variations.js
@@ -1,5 +1,5 @@
 import {Feature} from './opentype';
-import r from 'restructure';
+import * as r from 'restructure';
 
 /*******************
  * Variation Store *

--- a/src/tables/vhea.js
+++ b/src/tables/vhea.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 // Vertical Header Table
 export default new r.Struct({

--- a/src/tables/vmtx.js
+++ b/src/tables/vmtx.js
@@ -1,4 +1,4 @@
-import r from 'restructure';
+import * as r from 'restructure';
 
 let VmtxEntry = new r.Struct({
   advance: r.uint16,  // The advance height of the glyph

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,3 +24,39 @@ export function range(index, end) {
   }
   return range;
 }
+
+export const asciiDecoder = new TextDecoder('ascii');
+
+// Based on https://github.com/niklasvh/base64-arraybuffer. MIT license.
+const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const LOOKUP = new Uint8Array(256);
+for (let i = 0; i < CHARS.length; i++) {
+  LOOKUP[CHARS.charCodeAt(i)] = i;
+}
+
+export function decodeBase64(base64) {
+  let bufferLength = base64.length * 0.75;
+
+  if (base64[base64.length - 1] === '=') {
+    bufferLength--;
+    if (base64[base64.length - 2] === '=') {
+      bufferLength--;
+    }
+  }
+
+  let bytes = new Uint8Array(bufferLength);
+  let p = 0;
+
+  for (let i = 0, len = base64.length; i < len; i += 4) {
+    let encoded1 = LOOKUP[base64.charCodeAt(i)];
+    let encoded2 = LOOKUP[base64.charCodeAt(i + 1)];
+    let encoded3 = LOOKUP[base64.charCodeAt(i + 2)];
+    let encoded4 = LOOKUP[base64.charCodeAt(i + 3)];
+
+    bytes[p++] = (encoded1 << 2) | (encoded2 >> 4);
+    bytes[p++] = ((encoded2 & 15) << 4) | (encoded3 >> 2);
+    bytes[p++] = ((encoded3 & 3) << 6) | (encoded4 & 63);
+  }
+
+  return bytes;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,10 @@ import * as fontkit from 'fontkit';
 import assert from 'assert';
 
 describe('fontkit', function () {
-  it('should open a font asynchronously', () =>
-    fontkit.open(new URL('data/OpenSans/OpenSans-Regular.ttf', import.meta.url), function (err, font) {
-      assert.equal(err, null);
-      return assert.equal(font.type, 'TTF');
-    })
-  );
+  it('should open a font asynchronously', async () => {
+    let font = await fontkit.open(new URL('data/OpenSans/OpenSans-Regular.ttf', import.meta.url));
+    assert.equal(font.type, 'TTF');
+  });
 
   it('should open a font synchronously', function () {
     let font = fontkit.openSync(new URL('data/OpenSans/OpenSans-Regular.ttf', import.meta.url));
@@ -45,11 +43,11 @@ describe('fontkit', function () {
     assert.equal(font.postscriptName, null);
   });
 
-  it('should error when opening an invalid font asynchronously', function () {
-    fontkit.open(new URL(import.meta.url), function (err, font) {
-      assert(err instanceof Error);
-      assert.equal(err.message, 'Unknown font format');
-    });
+  it('should error when opening an invalid font asynchronously', async function () {
+    assert.rejects(
+      fontkit.open(new URL(import.meta.url)),
+      'Unknown font format'
+    );
   });
 
   it('should error when opening an invalid font synchronously', function () {

--- a/test/opentype.js
+++ b/test/opentype.js
@@ -1,4 +1,4 @@
-import fontkit from 'fontkit';
+import * as fontkit from 'fontkit';
 import assert from 'assert';
 
 describe('opentype', function () {

--- a/test/subset.js
+++ b/test/subset.js
@@ -1,30 +1,26 @@
 import * as fontkit from 'fontkit';
 import assert from 'assert';
 import concat from 'concat-stream';
-// import CFFFont from '../src/cff/CFFFont';
-import r from 'restructure';
-// import CFFGlyph from '../src/glyph/CFFGlyph';
+import * as r from 'restructure';
 import fs from 'fs';
 
 describe('font subsetting', function () {
   describe('truetype subsetting', function () {
     let font = fontkit.openSync(new URL('data/OpenSans/OpenSans-Regular.ttf', import.meta.url));
 
-    it('should produce a subset', function (done) {
+    it('should produce a subset', function () {
       let subset = font.createSubset();
       for (let glyph of font.glyphsForString('hello')) {
         subset.includeGlyph(glyph);
       }
 
-      subset.encodeStream().pipe(concat(function (buf) {
-        let f = fontkit.create(buf);
-        assert.equal(f.numGlyphs, 5);
-        assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('h')[0].path.toSVG());
-        done();
-      }));
+      let buf = subset.encode();
+      let f = fontkit.create(buf);
+      assert.equal(f.numGlyphs, 5);
+      assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('h')[0].path.toSVG());
     });
 
-    it('should re-encode variation glyphs', function (done) {
+    it('should re-encode variation glyphs', function () {
       if (!fs.existsSync('/Library/Fonts/Skia.ttf')) return this.skip();
 
       let font = fontkit.openSync('/Library/Fonts/Skia.ttf', 'Bold');
@@ -33,47 +29,41 @@ describe('font subsetting', function () {
         subset.includeGlyph(glyph);
       }
 
-      subset.encodeStream().pipe(concat(function (buf) {
-        let f = fontkit.create(buf);
-        assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('e')[0].path.toSVG());
-        done();
-      }));
+      let buf = subset.encode();
+      let f = fontkit.create(buf);
+      assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('e')[0].path.toSVG());
     });
 
-    it('should handle composite glyphs', function (done) {
+    it('should handle composite glyphs', function () {
       let subset = font.createSubset();
       subset.includeGlyph(font.glyphsForString('é')[0]);
 
-      subset.encodeStream().pipe(concat(function (buf) {
-        let f = fontkit.create(buf);
-        assert.equal(f.numGlyphs, 4);
-        assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('é')[0].path.toSVG());
-        done();
-      }));
+      let buf = subset.encode();
+      let f = fontkit.create(buf);
+      assert.equal(f.numGlyphs, 4);
+      assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('é')[0].path.toSVG());
     });
 
-    it('should handle fonts with long index to location format (indexToLocFormat = 1)', function (done) {
+    it('should handle fonts with long index to location format (indexToLocFormat = 1)', function () {
       let font = fontkit.openSync(new URL('data/FiraSans/FiraSans-Regular.ttf', import.meta.url));
       let subset = font.createSubset();
       for (let glyph of font.glyphsForString('abcd')) {
         subset.includeGlyph(glyph);
       }
 
-      subset.encodeStream().pipe(concat(function (buf) {
-        let f = fontkit.create(buf);
-        assert.equal(f.numGlyphs, 5);
-        assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('a')[0].path.toSVG());
-        // must test also second glyph which has an odd loca index
-        assert.equal(f.getGlyph(2).path.toSVG(), font.glyphsForString('b')[0].path.toSVG());
-        done();
-      }));
+      let buf = subset.encode();
+      let f = fontkit.create(buf);
+      assert.equal(f.numGlyphs, 5);
+      assert.equal(f.getGlyph(1).path.toSVG(), font.glyphsForString('a')[0].path.toSVG());
+      // must test also second glyph which has an odd loca index
+      assert.equal(f.getGlyph(2).path.toSVG(), font.glyphsForString('b')[0].path.toSVG());
     });
   });
 
   describe('CFF subsetting', function () {
     let font = fontkit.openSync(new URL('data/SourceSansPro/SourceSansPro-Regular.otf', import.meta.url));
 
-    it('should produce a subset', function (done) {
+    it('should produce a subset', function () {
       let subset = font.createSubset();
       let iterable = font.glyphsForString('hello');
       for (let i = 0; i < iterable.length; i++) {
@@ -81,18 +71,16 @@ describe('font subsetting', function () {
         subset.includeGlyph(glyph);
       }
 
-      return subset.encodeStream().pipe(concat(function (buf) {
-        let stream = new r.DecodeStream(buf);
-        let CFFFont = font._tables['CFF '].constructor;
-        let CFFGlyph = iterable[0].constructor;
-        let cff = new CFFFont(stream);
-        let glyph = new CFFGlyph(1, [], { stream, 'CFF ': cff });
-        assert.equal(glyph.path.toSVG(), font.glyphsForString('h')[0].path.toSVG());
-        return done();
-      }));
+      let buf = subset.encode();
+      let stream = new r.DecodeStream(buf);
+      let CFFFont = font._tables['CFF '].constructor;
+      let CFFGlyph = iterable[0].constructor;
+      let cff = new CFFFont(stream);
+      let glyph = new CFFGlyph(1, [], { stream, 'CFF ': cff });
+      assert.equal(glyph.path.toSVG(), font.glyphsForString('h')[0].path.toSVG());
     });
 
-    it('should handle CID fonts', function (done) {
+    it('should handle CID fonts', function () {
       let f = fontkit.openSync(new URL('data/NotoSansCJK/NotoSansCJKkr-Regular.otf', import.meta.url));
       let subset = f.createSubset();
       let iterable = f.glyphsForString('갈휸');
@@ -101,20 +89,18 @@ describe('font subsetting', function () {
         subset.includeGlyph(glyph);
       }
 
-      return subset.encodeStream().pipe(concat(function (buf) {
-        let stream = new r.DecodeStream(buf);
-        let CFFFont = font._tables['CFF '].constructor;
-        let CFFGlyph = iterable[0].constructor;
-        let cff = new CFFFont(stream);
-        let glyph = new CFFGlyph(1, [], { stream, 'CFF ': cff });
-        assert.equal(glyph.path.toSVG(), f.glyphsForString('갈')[0].path.toSVG());
-        assert.equal(cff.topDict.FDArray.length, 2);
-        assert.deepEqual(cff.topDict.FDSelect.fds, [0, 1, 1]);
-        return done();
-      }));
+      let buf = subset.encode();
+      let stream = new r.DecodeStream(buf);
+      let CFFFont = font._tables['CFF '].constructor;
+      let CFFGlyph = iterable[0].constructor;
+      let cff = new CFFFont(stream);
+      let glyph = new CFFGlyph(1, [], { stream, 'CFF ': cff });
+      assert.equal(glyph.path.toSVG(), f.glyphsForString('갈')[0].path.toSVG());
+      assert.equal(cff.topDict.FDArray.length, 2);
+      assert.deepEqual(cff.topDict.FDSelect.fds, [0, 1, 1]);
     });
 
-    it('should produce a subset with asian punctuation corretly', function (done) {
+    it('should produce a subset with asian punctuation corretly', function () {
       const koreanFont = fontkit.openSync(new URL('data/NotoSansCJK/NotoSansCJKkr-Regular.otf', import.meta.url));
       const subset = koreanFont.createSubset();
       const iterable = koreanFont.glyphsForString('a。d');
@@ -123,19 +109,17 @@ describe('font subsetting', function () {
         subset.includeGlyph(glyph);
       }
 
-      return subset.encodeStream().pipe(concat(function (buf) {
-        const stream = new r.DecodeStream(buf);
-        let CFFFont = font._tables['CFF '].constructor;
-        let CFFGlyph = iterable[0].constructor;
-        const cff = new CFFFont(stream);
-        let glyph = new CFFGlyph(1, [], { stream, 'CFF ': cff });
-        assert.equal(glyph.path.toSVG(), koreanFont.glyphsForString('a')[0].path.toSVG());
-        glyph = new CFFGlyph(2, [], { stream, 'CFF ': cff });
-        assert.equal(glyph.path.toSVG(), koreanFont.glyphsForString('。')[0].path.toSVG());
-        glyph = new CFFGlyph(3, [], { stream, 'CFF ': cff });
-        assert.equal(glyph.path.toSVG(), koreanFont.glyphsForString('d')[0].path.toSVG());
-        return done();
-      }));
+      let buf = subset.encode();
+      const stream = new r.DecodeStream(buf);
+      let CFFFont = font._tables['CFF '].constructor;
+      let CFFGlyph = iterable[0].constructor;
+      const cff = new CFFFont(stream);
+      let glyph = new CFFGlyph(1, [], { stream, 'CFF ': cff });
+      assert.equal(glyph.path.toSVG(), koreanFont.glyphsForString('a')[0].path.toSVG());
+      glyph = new CFFGlyph(2, [], { stream, 'CFF ': cff });
+      assert.equal(glyph.path.toSVG(), koreanFont.glyphsForString('。')[0].path.toSVG());
+      glyph = new CFFGlyph(3, [], { stream, 'CFF ': cff });
+      assert.equal(glyph.path.toSVG(), koreanFont.glyphsForString('d')[0].path.toSVG());
     });
   });
 });


### PR DESCRIPTION
Requires https://github.com/foliojs/restructure/pull/48

This removes all node-specific dependencies from fontkit. This means usages of Buffer have been replaced with Uint8Array/TextEncoder/TextDecoder. In addition, streams have been removed. This was only used for encoding subsets. Now you call `subset.encode()` rather than `subset.encodeStream()` and get back a Uint8Array. The streaming API didn't really offer much benefit anyway. iconv-lite has also been dropped.

There are actually 4 different builds: CommonJS and ESM for Node, as well as both for the browser as well. The difference is that the Node build includes the `fs` related functions `open` and `openSync`, whereas the browser version does not.

Due to breaking changes, this will be released in a major version bump.