### PR TITLE
Add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,15 @@
   "module": "dist/browser-module.mjs",
   "source": "src/index.js",
   "exports": {
-    "node": {
-      "import": "./dist/module.mjs",
-      "require": "./dist/main.cjs"
+    ".": {
+      "node": {
+        "import": "./dist/module.mjs",
+        "require": "./dist/main.cjs"
+      },
+      "import": "./dist/browser-module.mjs",
+      "require": "./dist/browser.cjs"
     },
-    "import": "./dist/browser-module.mjs",
-    "require": "./dist/browser.cjs"
+    "./package.json": "./package.json"
   },
   "targets": {
     "main": {


### PR DESCRIPTION
Fixes #287.

This PR adds the `package.json` to the fontkit module's exports so that we can obtain version information in dependent packages.