### PR TITLE
Bump unicode-properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4876,9 +4876,9 @@
       }
     },
     "node_modules/unicode-properties": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.0.tgz",
-      "integrity": "sha512-QD9DdmYM9KsHFKdD9BdkVkefnRuGhgQi/fa8Q1681ukVGUj+wLjGthsGiKILZOB5RxDCpojU4QgAiJjrX2F7ig==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "unicode-trie": "^2.0.0"
@@ -8486,9 +8486,9 @@
       }
     },
     "unicode-properties": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.0.tgz",
-      "integrity": "sha512-QD9DdmYM9KsHFKdD9BdkVkefnRuGhgQi/fa8Q1681ukVGUj+wLjGthsGiKILZOB5RxDCpojU4QgAiJjrX2F7ig==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
       "requires": {
         "base64-js": "^1.3.0",
         "unicode-trie": "^2.0.0"


### PR DESCRIPTION
Bumps unicode-properties in `package-lock.json` so that we avoid the following errors:

```
Error: Cannot find module '.../fontkit/node_modules/unicode-properties/dist.main.cjs'
```