### PR TITLE
`vhea` and `glyf` fixes

### DIFF
--- a/src/glyph/Path.js
+++ b/src/glyph/Path.js
@@ -63,6 +63,14 @@ export default class Path {
         }
       }
 
+      if (this.commands.length === 0) {
+        // No content, put 0 instead of Infinity
+        cbox.minX = 0;
+        cbox.minY = 0;
+        cbox.maxX = 0;
+        cbox.maxY = 0;
+      }
+
       this._cbox = Object.freeze(cbox);
     }
 
@@ -170,6 +178,14 @@ export default class Path {
           cy = p3y;
           break;
       }
+    }
+
+    if (this.commands.length === 0) {
+      // No content, put 0 instead of Infinity
+      bbox.minX = 0;
+      bbox.minY = 0;
+      bbox.maxX = 0;
+      bbox.maxY = 0;
     }
 
     return this._bbox = Object.freeze(bbox);

--- a/src/glyph/TTFGlyph.js
+++ b/src/glyph/TTFGlyph.js
@@ -74,8 +74,16 @@ export default class TTFGlyph extends Glyph {
       return this.path.cbox;
     }
 
+    let glyfPos = this._font.loca.offsets[this.id];
+    let nextPos = this._font.loca.offsets[this.id + 1];
+
+    // No data for this glyph (space?)
+    if (glyfPos === nextPos) {
+      return super._getCBox();
+    }
+
     let stream = this._font._getTableStream('glyf');
-    stream.pos += this._font.loca.offsets[this.id];
+    stream.pos += glyfPos;
     let glyph = GlyfHeader.decode(stream);
 
     let cbox = new BBox(glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax);

--- a/src/tables/vhea.js
+++ b/src/tables/vhea.js
@@ -2,7 +2,8 @@ import * as r from 'restructure';
 
 // Vertical Header Table
 export default new r.Struct({
-  version:                r.uint16,  // Version number of the Vertical Header Table
+  majorVersion:           r.uint16,  // Major version number of the Vertical Header Table
+  minorVersion:           r.uint16,  // Minor version number of the Vertical Header Table
   ascent:                 r.int16,   // The vertical typographic ascender for this font
   descent:                r.int16,   // The vertical typographic descender for this font
   lineGap:                r.int16,   // The vertical typographic line gap for this font


### PR DESCRIPTION
1. This branch fixes a bug with the processing of the `vhea` table. The version should consist of two 16-bit numbers instead of one. Because of this, errors have previously occurred in the processing of some fonts that use a vertical matrix.

2. For TrueType fonts, the values in the `loca` table were not validated when calculating cbox. Therefore, the data from the `glyf` table was loaded even if it simply does not exist (for example, the space glyph). Added a basic check for the presence of data, and if there is none, it tries to calculate cbox using the "classic" method.

3. If the glyph does not contain drawing commands (and, accordingly, coordinate points), then cbox / bbox contained Infinity as minX, minY, maxX, maxY values. Again, say hello to space. Therefore, a check has been added for such a case, with setting all previously named parameters to zero, as is done in FreeType (https://gitlab.freedesktop.org/freetype/freetype/-/blob/4d8db130ea4342317581bab65fc96365ce806b77/src/truetype/ttgload.c#L1648).