### PR TITLE
Respect `useTypoMetrics`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following properties describe the general metrics of the font. See [here](ht
 * `underlinePosition` - the offset from the normal underline position that should be used
 * `underlineThickness` - the weight of the underline that should be used
 * `italicAngle` - if this is an italic font, the angle the cursor should be drawn at to match the font design
+* `lineHeight` - is the vertical space between adjacent lines (their baselines) of text, also known as leading. See [here](https://en.wikipedia.org/wiki/Leading) for more details.
 * `capHeight` - the height of capital letters above the baseline. See [here](http://en.wikipedia.org/wiki/Cap_height) for more details.
 * `xHeight`- the height of lower case letters. See [here](http://en.wikipedia.org/wiki/X-height) for more details.
 * `bbox` - the font’s bounding box, i.e. the box that encloses all glyphs in the font

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -64,23 +64,12 @@ export default class Glyph {
 
     let {advance:advanceWidth, bearing:leftBearing} = this._getTableMetrics(this._font.hmtx);
 
-    // For vertical metrics, use vmtx if available, or fall back to global data from OS/2 or hhea
+    // For vertical metrics, use vmtx if available, or fall back to global data
     if (this._font.vmtx) {
       var {advance:advanceHeight, bearing:topBearing} = this._getTableMetrics(this._font.vmtx);
-
     } else {
-      let os2;
-      if (typeof cbox === 'undefined' || cbox === null) { ({ cbox } = this); }
-
-      if ((os2 = this._font['OS/2']) && os2.version > 0) {
-        var advanceHeight = Math.abs(os2.typoAscender - os2.typoDescender);
-        var topBearing = os2.typoAscender - cbox.maxY;
-
-      } else {
-        let { hhea } = this._font;
-        var advanceHeight = Math.abs(hhea.ascent - hhea.descent);
-        var topBearing = hhea.ascent - cbox.maxY;
-      }
+      var advanceHeight = Math.abs(this._font.ascent - this._font.descent);
+      var topBearing = this._font.ascent - cbox.maxY;
     }
 
     if (this._font._variationProcessor && this._font.HVAR) {

--- a/src/glyph/Path.js
+++ b/src/glyph/Path.js
@@ -63,6 +63,14 @@ export default class Path {
         }
       }
 
+      if (this.commands.length === 0) {
+        // No content, put 0 instead of Infinity
+        cbox.minX = 0;
+        cbox.minY = 0;
+        cbox.maxX = 0;
+        cbox.maxY = 0;
+      }
+
       this._cbox = Object.freeze(cbox);
     }
 
@@ -170,6 +178,14 @@ export default class Path {
           cy = p3y;
           break;
       }
+    }
+
+    if (this.commands.length === 0) {
+      // No content, put 0 instead of Infinity
+      bbox.minX = 0;
+      bbox.minY = 0;
+      bbox.maxX = 0;
+      bbox.maxY = 0;
     }
 
     return this._bbox = Object.freeze(bbox);

--- a/src/glyph/TTFGlyph.js
+++ b/src/glyph/TTFGlyph.js
@@ -74,8 +74,16 @@ export default class TTFGlyph extends Glyph {
       return this.path.cbox;
     }
 
+    let glyfPos = this._font.loca.offsets[this.id];
+    let nextPos = this._font.loca.offsets[this.id + 1];
+
+    // No data for this glyph (space?)
+    if (glyfPos === nextPos) {
+      return super._getCBox();
+    }
+
     let stream = this._font._getTableStream('glyf');
-    stream.pos += this._font.loca.offsets[this.id];
+    stream.pos += glyfPos;
     let glyph = GlyfHeader.decode(stream);
 
     let cbox = new BBox(glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax);

--- a/src/tables/vhea.js
+++ b/src/tables/vhea.js
@@ -2,7 +2,8 @@ import * as r from 'restructure';
 
 // Vertical Header Table
 export default new r.Struct({
-  version:                r.uint16,  // Version number of the Vertical Header Table
+  majorVersion:           r.uint16,  // Major version number of the Vertical Header Table
+  minorVersion:           r.uint16,  // Minor version number of the Vertical Header Table
   ascent:                 r.int16,   // The vertical typographic ascender for this font
   descent:                r.int16,   // The vertical typographic descender for this font
   lineGap:                r.int16,   // The vertical typographic line gap for this font


### PR DESCRIPTION
1. This PR also contains the changes contained in #305 so that you can accept smaller changes while rejecting this PR (if you wish to do so).

2. At the moment, the library ignores the `useTypoMetrics` flag, which can lead to strange metrics in some cases. This branch solves this problem using the same algorithm as FreeType (https://gitlab.freedesktop.org/freetype/freetype/-/blob/4d8db130ea4342317581bab65fc96365ce806b77/src/sfnt/sfobjs.c#L1310).