### PR TITLE
A little more metrics for glyphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,14 @@ You do not create glyph objects directly. They are created by various methods on
 * `path` - a vector Path object representing the glyph
 * `bbox` - the glyph’s bounding box, i.e. the rectangle that encloses the glyph outline as tightly as possible.
 * `cbox` - the glyph’s control box. This is often the same as the bounding box, but is faster to compute. Because of the way bezier curves are defined, some of the control points can be outside of the bounding box. Where `bbox` takes this into account, `cbox` does not. Thus, `cbox` is less accurate, but faster to compute. See [here](http://www.freetype.org/freetype2/docs/glyphs/glyphs-6.html#section-2) for a more detailed description.
+* `width` - the glyph’s width.
+* `weight` - the glyph’s height.
 * `advanceWidth` - the glyph’s advance width.
+* `advanceHeight` - the glyph’s advance height.
+* `leftBearing` - the glyph’s left side bearing.
+* `topBearing` - the glyph’s top side bearing.
+* `rightBearing` - the glyph’s right side bearing.
+* `bottomBearing` - the glyph’s bottom side bearing.
 
 ### `glyph.render(ctx, size)`
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following properties describe the general metrics of the font. See [here](ht
 * `underlinePosition` - the offset from the normal underline position that should be used
 * `underlineThickness` - the weight of the underline that should be used
 * `italicAngle` - if this is an italic font, the angle the cursor should be drawn at to match the font design
+* `lineHeight` - is the vertical space between adjacent lines (their baselines) of text, also known as leading. See [here](https://en.wikipedia.org/wiki/Leading) for more details.
 * `capHeight` - the height of capital letters above the baseline. See [here](http://en.wikipedia.org/wiki/Cap_height) for more details.
 * `xHeight`- the height of lower case letters. See [here](http://en.wikipedia.org/wiki/X-height) for more details.
 * `bbox` - the font’s bounding box, i.e. the box that encloses all glyphs in the font

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -61,6 +61,7 @@ export default class Glyph {
 
   _getMetrics(cbox) {
     if (this._metrics) { return this._metrics; }
+    if (typeof cbox === 'undefined' || cbox === null) { ({ cbox } = this); }
 
     let {advance:advanceWidth, bearing:leftBearing} = this._getTableMetrics(this._font.hmtx);
 
@@ -76,7 +77,21 @@ export default class Glyph {
       advanceWidth += this._font._variationProcessor.getAdvanceAdjustment(this.id, this._font.HVAR);
     }
 
-    return this._metrics = { advanceWidth, advanceHeight, leftBearing, topBearing };
+    let width = cbox.width;
+    let height = cbox.height;
+    let rightBearing = advanceWidth - leftBearing - width;
+    let bottomBearing = advanceHeight - topBearing - height;
+
+    return this._metrics = {
+      width,
+      height,
+      advanceWidth,
+      advanceHeight,
+      leftBearing,
+      topBearing,
+      rightBearing,
+      bottomBearing
+    };
   }
 
   /**
@@ -127,6 +142,24 @@ export default class Glyph {
   }
 
   /**
+   * The glyph's width.
+   * @type {number}
+   */
+  @cache
+  get width() {
+    return this._getMetrics().width;
+  }
+
+  /**
+   * The glyph's height.
+   * @type {number}
+   */
+  @cache
+  get height() {
+    return this._getMetrics().height;
+  }
+
+  /**
    * The glyph's advance width.
    * @type {number}
    */
@@ -142,6 +175,43 @@ export default class Glyph {
   @cache
   get advanceHeight() {
     return this._getMetrics().advanceHeight;
+  }
+
+  /**
+   * The glyph's left side bearing.
+   * @type {number}
+   */
+  @cache
+  get leftBearing() {
+    return this._getMetrics().leftBearing;
+  }
+
+
+  /**
+   * The glyph's top side bearing.
+   * @type {number}
+   */
+  @cache
+  get topBearing() {
+    return this._getMetrics().topBearing;
+  }
+
+  /**
+   * The glyph's right side bearing.
+   * @type {number}
+   */
+  @cache
+  get rightBearing() {
+    return this._getMetrics().rightBearing;
+  }
+
+  /**
+   * The glyph's bottom side bearing.
+   * @type {number}
+   */
+  @cache
+  get bottomBearing() {
+    return this._getMetrics().bottomBearing;
   }
 
   get ligatureCaretPositions() {}

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -64,23 +64,12 @@ export default class Glyph {
 
     let {advance:advanceWidth, bearing:leftBearing} = this._getTableMetrics(this._font.hmtx);
 
-    // For vertical metrics, use vmtx if available, or fall back to global data from OS/2 or hhea
+    // For vertical metrics, use vmtx if available, or fall back to global data
     if (this._font.vmtx) {
       var {advance:advanceHeight, bearing:topBearing} = this._getTableMetrics(this._font.vmtx);
-
     } else {
-      let os2;
-      if (typeof cbox === 'undefined' || cbox === null) { ({ cbox } = this); }
-
-      if ((os2 = this._font['OS/2']) && os2.version > 0) {
-        var advanceHeight = Math.abs(os2.typoAscender - os2.typoDescender);
-        var topBearing = os2.typoAscender - cbox.maxY;
-
-      } else {
-        let { hhea } = this._font;
-        var advanceHeight = Math.abs(hhea.ascent - hhea.descent);
-        var topBearing = hhea.ascent - cbox.maxY;
-      }
+      var advanceHeight = Math.abs(this._font.ascent - this._font.descent);
+      var topBearing = this._font.ascent - cbox.maxY;
     }
 
     if (this._font._variationProcessor && this._font.HVAR) {

--- a/src/glyph/Path.js
+++ b/src/glyph/Path.js
@@ -63,6 +63,14 @@ export default class Path {
         }
       }
 
+      if (this.commands.length === 0) {
+        // No content, put 0 instead of Infinity
+        cbox.minX = 0;
+        cbox.minY = 0;
+        cbox.maxX = 0;
+        cbox.maxY = 0;
+      }
+
       this._cbox = Object.freeze(cbox);
     }
 
@@ -170,6 +178,14 @@ export default class Path {
           cy = p3y;
           break;
       }
+    }
+
+    if (this.commands.length === 0) {
+      // No content, put 0 instead of Infinity
+      bbox.minX = 0;
+      bbox.minY = 0;
+      bbox.maxX = 0;
+      bbox.maxY = 0;
     }
 
     return this._bbox = Object.freeze(bbox);

--- a/src/glyph/TTFGlyph.js
+++ b/src/glyph/TTFGlyph.js
@@ -74,8 +74,16 @@ export default class TTFGlyph extends Glyph {
       return this.path.cbox;
     }
 
+    let glyfPos = this._font.loca.offsets[this.id];
+    let nextPos = this._font.loca.offsets[this.id + 1];
+
+    // No data for this glyph (space?)
+    if (glyfPos === nextPos) {
+      return super._getCBox();
+    }
+
     let stream = this._font._getTableStream('glyf');
-    stream.pos += this._font.loca.offsets[this.id];
+    stream.pos += glyfPos;
     let glyph = GlyfHeader.decode(stream);
 
     let cbox = new BBox(glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax);

--- a/src/tables/vhea.js
+++ b/src/tables/vhea.js
@@ -2,7 +2,8 @@ import * as r from 'restructure';
 
 // Vertical Header Table
 export default new r.Struct({
-  version:                r.uint16,  // Version number of the Vertical Header Table
+  majorVersion:           r.uint16,  // Major version number of the Vertical Header Table
+  minorVersion:           r.uint16,  // Minor version number of the Vertical Header Table
   ascent:                 r.int16,   // The vertical typographic ascender for this font
   descent:                r.int16,   // The vertical typographic descender for this font
   lineGap:                r.int16,   // The vertical typographic line gap for this font


### PR DESCRIPTION
1. Это PR содержит в также себе изменения, которые содержатся в #306 и #305, для того, чтобы можно было принять более мелкие изменения, отклонив при этом данный PR (если вы пожелаете так сделать).

2. Данная ветка добавляет в публичное API глифов несколько новых полей, а именно width, height, advanceHeight, leftBearing, topBearing, rightBearing, bottomBearing.