### PR TITLE
includeTable for subset

### DIFF
--- a/src/subset/Subset.js
+++ b/src/subset/Subset.js
@@ -7,6 +7,7 @@ export default class Subset {
     this.font = font;
     this.glyphs = [];
     this.mapping = {};
+    this.tables = [];
 
     // always include the missing glyph
     this.includeGlyph(0);
@@ -24,4 +25,11 @@ export default class Subset {
 
     return this.mapping[glyph];
   }
+
+  includeTable(table) {
+    if (typeof table === 'string' && table.length === 4) {
+      this.tables.push(table);
+    }
+  }
+
 }

--- a/src/subset/TTFSubset.js
+++ b/src/subset/TTFSubset.js
@@ -109,23 +109,24 @@ export default class TTFSubset extends Subset {
     //     ]
 
     // TODO: subset prep, cvt, fpgm?
-    return Directory.toBuffer({
-      tables: {
-        head,
-        hhea,
-        loca: this.loca,
-        maxp,
-        'cvt ': this.font['cvt '],
-        prep: this.font.prep,
-        glyf: this.glyf,
-        hmtx: this.hmtx,
-        fpgm: this.font.fpgm
+    // The following is the minimum set of tables.
+    let t =  {
+      head,
+      hhea,
+      loca: this.loca,
+      maxp,
+      'cvt ': this.font['cvt '],
+      prep: this.font.prep,
+      glyf: this.glyf,
+      hmtx: this.hmtx,
+      fpgm: this.font.fpgm,
+    }
 
-        // name: clone @font.name
-        // 'OS/2': clone @font['OS/2']
-        // post: clone @font.post
-        // cmap: cmap
-      }
-    });
+    for (const i in this.tables) {
+      const table = this.tables[i];
+      t[table] = cloneDeep(this.font[table]);
+    }
+
+    return Directory.toBuffer({tables: t});
   }
 }

--- a/test/subset.js
+++ b/test/subset.js
@@ -58,6 +58,19 @@ describe('font subsetting', function () {
       // must test also second glyph which has an odd loca index
       assert.equal(f.getGlyph(2).path.toSVG(), font.glyphsForString('b')[0].path.toSVG());
     });
+
+    it('should produce a subset including font table OS/2', function () {
+      let subset = font.createSubset();
+      for (let glyph of font.glyphsForString('hello')) {
+        subset.includeGlyph(glyph);
+      }
+      subset.includeTable('OS/2');
+
+      let buf = subset.encode();
+      let f = fontkit.create(buf);      
+      assert.equal(f.hasOwnProperty('OS/2'), true);
+    });
+
   });
 
   describe('CFF subsetting', function () {


### PR DESCRIPTION
Adding new functionality for subsetted font which allows you to keep specific tables if specified via includeTable()