### PR TITLE
Fix: Handle Undefined Axis Property Error

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -449,8 +449,9 @@ export default class TTFFont {
     }
 
     for (let axis of this.fvar.axis) {
+      const name = axis.name && axis.name.en ? axis.name.en : axis.axisTag.trim();
       res[axis.axisTag.trim()] = {
-        name: axis.name.en,
+        name,
         min: axis.minValue,
         default: axis.defaultValue,
         max: axis.maxValue


### PR DESCRIPTION
Fixed the problem of undefined axis.name.en 

```
fontkit/dist/module.mjs:12699
name: axis.name.en,
                ^
TypeError: Cannot read properties of undefined (reading 'en')
```
Property by implementing axis tag trimming when the value is not readable. 

Related to #297 #272

Font in error exemple : 

https://github.com/clauseggers/Playfair/blob/master/fonts/VF-TTF/PlayfairItalicVF.ttf


output: 

```

{
  opsz: { name: 'Optical size', min: 5, default: 1200, max: 1200 },
  wdth: { name: 'Width', min: 88, default: 88, max: 113 },
  wght: { name: 'Weight', min: 300, default: 300, max: 900 },
  ital: { name: 'ital', min: 1, default: 1, max: 1 }
}

```



