### PR TITLE
fix #182: apply rounding after delta interpolation

### DIFF
--- a/src/glyph/GlyphVariationProcessor.js
+++ b/src/glyph/GlyphVariationProcessor.js
@@ -160,8 +160,8 @@ export default class GlyphVariationProcessor {
             let point = outPoints[idx];
             hasDelta[idx] = true;
 
-            point.x += Math.round(xDeltas[i] * factor);
-            point.y += Math.round(yDeltas[i] * factor);
+            point.x += xDeltas[i] * factor;
+            point.y += yDeltas[i] * factor;
           }
         }
 
@@ -171,8 +171,8 @@ export default class GlyphVariationProcessor {
           let deltaX = outPoints[i].x - origPoints[i].x;
           let deltaY = outPoints[i].y - origPoints[i].y;
 
-          glyphPoints[i].x += deltaX;
-          glyphPoints[i].y += deltaY;
+          glyphPoints[i].x = Math.round(glyphPoints[i].x + deltaX);
+          glyphPoints[i].y = Math.round(glyphPoints[i].y + deltaY);
         }
       }
 


### PR DESCRIPTION
rounding after the delta interpolation instead of before prevents rounding issues leading do wrong value, e.g. in the unicode test suite case GVAR-9, column 4:
![image](https://github.com/foliojs/fontkit/assets/13076806/d243162e-c882-4da3-857c-9d7a8cbf15a1)

fixes #182 