### PR TITLE
Downgrades and locks to restructure 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "clone": "^2.1.2",
     "dfa": "^1.2.0",
     "fast-deep-equal": "^3.1.3",
-    "restructure": "^3.0.0",
+    "restructure": "3.0.0",
     "tiny-inflate": "^1.0.3",
     "unicode-properties": "^1.4.0",
     "unicode-trie": "^2.0.0"


### PR DESCRIPTION
Fixes https://github.com/foliojs/fontkit/issues/336

I'm not sure why restructure 3.0.1 is breaking font name loading but it is. This should lock to 3.0.0. 