### PR TITLE
Fix codePointsForGlyph() for values >= 0xffff

### DIFF
--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -248,7 +248,7 @@ export default class CmapProcessor {
               }
             }
 
-            if (g === gid) {
+            if ((g & 0xffff) === gid) {
               res.push(c);
             }
           }


### PR DESCRIPTION
At Lineto we have a typeface where the following code does not retrieve all code-points correctly:

```js
  for (const codePoint of font.characterSet) {
    const glyph = font.glyphForCodePoint(codePoint)
    console.log(
      glyph.name,
      codePoint,
      font._cmapProcessor.codePointsForGlyph(glyph.id)[0]
    )
  }
 ```
 
 For most glyphs, I am getting correct results, such as:
 
 ```
.null 0 0
uni000D 13 13
space 32 32
exclam 33 33
quotedbl 34 34
numbersign 35 35
dollar 36 36
percent 37 37
ampersand 38 38
quotesingle 39 39
parenleft 40 40
…
```

But for quite a few, `codePointsForGlyph()` doesn't produce the inverse of `glyphForCodePoint()`:

```
uniE001 57345 undefined
uniE002 57346 undefined
uniE100 57600 undefined
uniE101 57601 undefined
uniE102 57602 undefined
uniE103 57603 undefined
uniE104 57604 undefined
uniE105 57605 undefined
uniE106 57606 undefined
uniE107 57607 undefined
uniE108 57608 undefined
uniE109 57609 undefined
uniE10A 57610 undefined
uniE10B 57611 undefined
uniE10C 57612 undefined
uniE10D 57613 undefined
…
```

This simple PR fixes this bug.