### PR TITLE
Fix for the bug where the default language in global settings cannot be changed

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -96,14 +96,14 @@ export default class TTFFont {
    * `lang` is a BCP-47 language code.
    * @return {string}
    */
-  getName(key, lang = this.defaultLanguage || fontkit.defaultLanguage) {
+  getName(key, lang = this.defaultLanguage || fontkit.defaultLanguage()) {
     let record = this.name && this.name.records[key];
     if (record) {
       // Attempt to retrieve the entry, depending on which translation is available:
       return (
           record[lang]
           || record[this.defaultLanguage]
-          || record[fontkit.defaultLanguage]
+          || record[fontkit.defaultLanguage()]
           || record['en']
           || record[Object.keys(record)[0]] // Seriously, ANY language would be fine
           || null

--- a/src/base.js
+++ b/src/base.js
@@ -23,7 +23,12 @@ export function create(buffer, postscriptName) {
   throw new Error('Unknown font format');
 };
 
-export let defaultLanguage = 'en';
+let _defaultLanguage = 'en';
+
+export function defaultLanguage() {
+  return _defaultLanguage;
+}
+
 export function setDefaultLanguage(lang = 'en') {
-  defaultLanguage = lang;
+  _defaultLanguage = lang;
 };

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -23,7 +23,7 @@ describe('i18n', function () {
 
     it('can set global default language to "ar"', function () {
       fontkit.setDefaultLanguage('ar');
-      assert.equal(fontkit.defaultLanguage, 'ar');
+      assert.equal(fontkit.defaultLanguage(), 'ar');
     });
 
     it('font now has "ar" metadata properties', function () {
@@ -37,7 +37,7 @@ describe('i18n', function () {
 
     it('can reset default language back to "en"', function () {
       fontkit.setDefaultLanguage();
-      assert.equal(fontkit.defaultLanguage, "en");
+      assert.equal(fontkit.defaultLanguage(), "en");
     });
   });
 


### PR DESCRIPTION
The test code resulted in the following error.

```
  1) i18n
       fontkit.setDefaultLanguage
         can set global default language to "ar":

      AssertionError [ERR_ASSERTION]: 'en' == 'ar'
      + expected - actual

      -en
      +ar
      
      at Context.<anonymous> (file:///Users/omochi/temp/fontkit/test/i18n.js:30:14)
      at process.processImmediate (node:internal/timers:483:21)
```

This patch fix the issue.

## Bug detail

In `base.js`, a string value is being exported as `let defaultLanguage`, but since exported members are copied when imported, calling `setDefaultLanguage` afterwards does not reflect the change.

## Fix

I will change `defaultLanguage` from a value to a getter function.

## Environment

macOS Sequoia 15.1 Beta 24B5046f
nodejs v22.5.1