### PR TITLE
Handle possible undefined anchors

### DIFF
--- a/src/opentype/GPOSProcessor.js
+++ b/src/opentype/GPOSProcessor.js
@@ -285,6 +285,9 @@ export default class GPOSProcessor extends OTProcessor {
   }
 
   getAnchor(anchor) {
+    if (anchor == null) {
+      return { x: 0, y: 0 };
+    }
     // TODO: contour point, device tables
     let x = anchor.xCoordinate;
     let y = anchor.yCoordinate;


### PR DESCRIPTION
This fixes #265 normalizing getAnchor function and ensuring always a valid coordinate value is returned, in this case (0,0)