### PR TITLE
Fix chaining context backtrack matching order

### DIFF
--- a/src/opentype/OTProcessor.js
+++ b/src/opentype/OTProcessor.js
@@ -393,7 +393,9 @@ export default class OTProcessor {
 
         let set = table.chainRuleSets[index];
         for (let rule of set) {
-          if (this.sequenceMatches(-rule.backtrack.length, rule.backtrack)
+          // Backtrack is stored in reverse order per OpenType spec, so reverse
+          // it before matching forward from the start position.
+          if (this.sequenceMatches(-rule.backtrack.length, [...rule.backtrack].reverse())
             && this.sequenceMatches(1, rule.input)
             && this.sequenceMatches(1 + rule.input.length, rule.lookahead)) {
             return this.applyLookupList(rule.lookupRecords);
@@ -414,7 +416,8 @@ export default class OTProcessor {
         }
 
         for (let rule of rules) {
-          if (this.classSequenceMatches(-rule.backtrack.length, rule.backtrack, table.backtrackClassDef) &&
+          // Backtrack is stored in reverse order per OpenType spec.
+          if (this.classSequenceMatches(-rule.backtrack.length, [...rule.backtrack].reverse(), table.backtrackClassDef) &&
             this.classSequenceMatches(1, rule.input, table.inputClassDef) &&
             this.classSequenceMatches(1 + rule.input.length, rule.lookahead, table.lookaheadClassDef)) {
             return this.applyLookupList(rule.lookupRecords);
@@ -424,7 +427,8 @@ export default class OTProcessor {
         break;
 
       case 3:
-        if (this.coverageSequenceMatches(-table.backtrackGlyphCount, table.backtrackCoverage) &&
+        // Backtrack is stored in reverse order per OpenType spec.
+        if (this.coverageSequenceMatches(-table.backtrackGlyphCount, [...table.backtrackCoverage].reverse()) &&
           this.coverageSequenceMatches(0, table.inputCoverage) &&
           this.coverageSequenceMatches(table.inputGlyphCount, table.lookaheadCoverage)) {
           return this.applyLookupList(table.lookupRecords);

--- a/test/shaping.js
+++ b/test/shaping.js
@@ -56,6 +56,15 @@ describe('shaping', function () {
       '218+545|11+1781|94+1362|26@35,0+1139|34+564|32+1250|3+532|9+1904|96+1088|93+1383|51+569|8+1904|' +
       '3+532|33+1225|21+1470|3+532|96+1088|17+1496|96+1088|17+1496|32+1250|3+532|9+1904|95+1104|12+1781|39+1052');
 
+    // Exercises chain context backtrack ordering: the Syriac `calt` chain rule
+    // requires backtrack[0] (mark uni0731) immediately before the input glyph
+    // (uni0713.Fina) and backtrack[1] (uni0712.Init) one position further
+    // back. Without reversing the backtrack array, fontkit matches in stored
+    // order and the rule fails to fire, leaving uni0713.Fina unsubstituted.
+    test('should match chain context backtrack in OpenType spec order',
+      'NotoSans/NotoSansSyriacEstrangela-Regular.ttf', 'ܒܱܓ',
+      '249+2485|141@606,-200+0|17+1496');
+
     test('should shape N\'Ko text', 'NotoSans/NotoSansNKo-Regular.ttf', 'ߞߊ߬ ߞߐߕߐ߮ ߞߎߘߊ ߘߏ߫ ߘߊߦߟߍ߬ ߸ ߏ߬',
       '52@10,-300+0|23+1128|3+532|64+985|3+532|52@150,-300+0|84+1268|139+1184|160+1067|76+543|119+1622|3+532|51@10,-300+0|90+1128' +
       '|119+1622|3+532|75+543|118+1622|88+1212|137+1114|3+532|54@170,0+0|93+1321|109+1155|94+1321|137+1114|3+532|52@-210,0+0|75+543|137+1114');


### PR DESCRIPTION
The chaining-context lookup (GSUB type 6, formats 1–3) stores backtrack coverage/class/glyph arrays in reverse buffer order per the OpenType spec: `backtrack[0]` is the glyph immediately before the input, `backtrack[1]` is one further back, etc. The current matcher feeds the stored order directly to `sequenceMatches(-N, …)`, which iterates forward — so it ends up comparing `backtrack[0]` against the position farthest from the input. When all backtrack positions accept the same coverage (the common case) the bug is invisible, but rules with distinct positions silently fail to fire.

The fix reverses the backtrack array before matching, in all three chain-context formats.

### Test

Added a shaping test using Noto Sans Syriac Estrangela's `calt` chain rule where:

- `backtrack[0]` accepts a mark glyph (`uni0731`/`uni0734`/`uni0737`)
- `backtrack[1]` accepts a positional consonant (`uni0712.Init`/`uni0712.Medi`/`uni071A.Medi`)
- input is `uni0713.Fina`, substituted to `uni0713.FinaWide`

Input `ܒܱܓ` (U+0712 U+0731 U+0713) joins to `[uni0712.Init, uni0731, uni0713.Fina]`. Per spec the rule fires and produces `uni0713.FinaWide` (matching HarfBuzz); without the fix fontkit leaves `uni0713.Fina` unsubstituted.