### PR TITLE
Fix empty CFF subset charset range

### DIFF
--- a/src/subset/CFFSubset.js
+++ b/src/subset/CFFSubset.js
@@ -133,7 +133,7 @@ export default class CFFSubset extends Subset {
 
     let charset = {
       version: this.charstrings.length > 255 ? 2 : 1,
-      ranges: [{ first: 1, nLeft: this.charstrings.length - 2 }]
+      ranges: this.charstrings.length > 1 ? [{ first: 1, nLeft: this.charstrings.length - 2 }] : []
     };
 
     let topDict = Object.assign({}, this.cff.topDict);


### PR DESCRIPTION
## Summary

This fixes CFF subset generation when the subset only contains `.notdef`.

In that case, `this.charstrings.length` is `1`, so the existing code creates a charset range with `nLeft: -1`. That produces an invalid unsigned value during encoding.

This change emits no charset ranges when there are no glyphs after `.notdef`.

## Change

```js
ranges: this.charstrings.length > 1
  ? [{ first: 1, nLeft: this.charstrings.length - 2 }]
  : []
```